### PR TITLE
ci: generate AI release highlights for the Playnite changelog

### DIFF
--- a/.github/workflows/release-highlights.yml
+++ b/.github/workflows/release-highlights.yml
@@ -1,0 +1,43 @@
+name: Release Highlights
+
+# Adds an AI-drafted "### Highlights" section to CHANGELOG.md on release-please
+# PRs. The bullets are reviewed (and editable) in the release PR like any other
+# change; update-installer-manifest.ps1 prefers them for the Playnite changelog.
+on:
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  highlights:
+    # Same-repo release-please branches only. Fork PRs never receive secrets on
+    # the pull_request trigger, but this guard stops spoofed-branch-name runs
+    # from even starting.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.head_ref, 'release-please--')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout release PR branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+      - name: Generate release highlights
+        shell: pwsh
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: ./scripts/generate-release-highlights.ps1
+
+      # The generation script is idempotent (no-op when Highlights already
+      # exist), so the synchronize event triggered by this push does not loop.
+      - name: Commit highlights to release PR
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git diff --cached --quiet || { git commit -m "docs: add release highlights"; git push; }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,13 @@ Hook scripts in `hooks/` are installed to `.git/hooks/` via `scripts/setup-hooks
 - Adding a new `.cs` file requires a `<Compile Include="Folder\FileName.cs" />` entry in `GsPlugin.csproj` (old-style non-SDK project — files are not auto-included). Place files in the appropriate namespace folder (`Api/`, `Services/`, `Models/`, `Infrastructure/`, `View/`).
 - New `.cs` files written with LF line endings will fail `dotnet format --verify-no-changes`; run `dotnet format` to auto-correct to CRLF.
 
+### Release Highlights (User-Facing Changelog)
+- Playnite shows users the `Changelog` entries from `installer_manifest.yaml`, not CHANGELOG.md. CHANGELOG.md stays technical (for developers); the Playnite-facing text is curated separately.
+- `.github/workflows/release-highlights.yml` runs on release-please PR branches (`release-please--*`): `scripts/generate-release-highlights.ps1` calls the Anthropic API (repo secret `ANTHROPIC_API_KEY`, model `claude-sonnet-5`) with the commits and diff since the last release tag, and inserts a `### Highlights` section under the new version heading in CHANGELOG.md, committed back to the release PR.
+- Highlights are reviewed/edited in the release PR like any other change — edit the bullets there before merging to change what users see in Playnite.
+- The script is idempotent (no-ops when `### Highlights` already exists for the version, which also breaks the push→synchronize workflow loop) and best-effort: missing API key, API failure, or bad output warns and exits 0 so the release PR is never blocked.
+- `scripts/update-installer-manifest.ps1` prefers `### Highlights` bullets for the manifest; when absent it falls back to the raw Features/Bug Fixes bullets.
+
 ### Sentry Release Management
 - Runtime: Plugin reports version as `GsPlugin@X.Y.Z` from AssemblyInfo
 - CI/CD: GitHub Actions creates Sentry releases, uploads portable PDB files (`--type=portablepdb`), and associates commits

--- a/scripts/generate-release-highlights.ps1
+++ b/scripts/generate-release-highlights.ps1
@@ -1,0 +1,136 @@
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$ChangelogFile = "CHANGELOG.md",
+
+    [Parameter(Mandatory = $false)]
+    [string]$ManifestFile = ".release-please-manifest.json",
+
+    [Parameter(Mandatory = $false)]
+    [string]$Model = "claude-sonnet-5",
+
+    [Parameter(Mandatory = $false)]
+    [string]$TagPrefix = "GsPlugin-v",
+
+    [Parameter(Mandatory = $false)]
+    [int]$MaxDiffChars = 60000,
+
+    # Skips git + API calls and inserts canned bullets. For local testing of the
+    # changelog insertion/idempotency logic only.
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+
+# Highlights are best-effort: any failure warns and exits 0 so the release PR is
+# never blocked. update-installer-manifest.ps1 falls back to raw changelog bullets.
+function Write-Skip([string]$Message) {
+    Write-Host "::warning::$Message - skipping highlights generation (installer manifest will fall back to raw changelog bullets)"
+}
+
+$version = (Get-Content -Path $ManifestFile -Raw | ConvertFrom-Json).'.'
+if (-not $version) {
+    Write-Skip "Could not read version from $ManifestFile"
+    exit 0
+}
+Write-Host "Generating release highlights for version $version"
+
+$changelog = Get-Content -Path $ChangelogFile -Raw
+$escapedVersion = [regex]::Escape($version)
+
+$headingMatch = [regex]::Match($changelog, "(?m)^## \[$escapedVersion\][^\r\n]*")
+if (-not $headingMatch.Success) {
+    Write-Skip "No '## [$version]' heading found in $ChangelogFile"
+    exit 0
+}
+
+$sectionMatch = [regex]::Match($changelog, "## \[$escapedVersion\].*?\n(.*?)(?=\n## \[|$)", [System.Text.RegularExpressions.RegexOptions]::Singleline)
+if ($sectionMatch.Success -and $sectionMatch.Value -match '### Highlights') {
+    Write-Host "Highlights already present for $version, nothing to do."
+    exit 0
+}
+
+if ($DryRun) {
+    $bullets = @("* Dry-run highlight one", "* Dry-run highlight two")
+}
+else {
+    if (-not $env:ANTHROPIC_API_KEY) {
+        Write-Skip "ANTHROPIC_API_KEY is not set"
+        exit 0
+    }
+
+    # The release-please PR branch is based on main; the release content is
+    # everything on main since the previous release tag.
+    $prevTag = git tag --list "$TagPrefix*" --sort=-v:refname | Select-Object -First 1
+    $null = git rev-parse --verify "origin/main" 2>$null
+    $target = if ($LASTEXITCODE -eq 0) { "origin/main" } else { "HEAD" }
+    $range = if ($prevTag) { "$prevTag..$target" } else { $target }
+    Write-Host "Summarizing commit range: $range"
+
+    $excludePaths = @(":(exclude)CHANGELOG.md", ":(exclude)installer_manifest.yaml", ":(exclude).release-please-manifest.json")
+    $commitLog = (git log $range --no-merges --pretty=format:"%s%n%b---") -join "`n"
+    $diffStat = (git diff $range --stat -- . $excludePaths) -join "`n"
+    $diff = (git diff $range -- . $excludePaths) -join "`n"
+    if ($diff.Length -gt $MaxDiffChars) {
+        $diff = $diff.Substring(0, $MaxDiffChars) + "`n[diff truncated]"
+    }
+
+    $systemPrompt = "You write user-facing release notes for Game Scrobbler, a Playnite (desktop game library manager) extension that automatically tracks play sessions, syncs the user's game library and achievements, and shows stats and dashboards on gamescrobbler.com. Your audience is gamers, not developers."
+
+    $userPrompt = @"
+Below are the commits and code changes going into Game Scrobbler release $version. Write the "Highlights" bullets for the Playnite add-on changelog that players read before updating.
+
+Rules:
+- Output ONLY bullet lines, each starting with "* ". No headings, intro, or closing text.
+- 2 to 6 bullets, each a single sentence under 140 characters.
+- Plain, friendly language - no technical jargon, class names, commit hashes, or commit-type prefixes.
+- Describe user-visible benefits (what's new, what works better). Merge related commits into one bullet.
+- Skip purely internal changes (refactors, CI, tests, logging) unless they have a clear user benefit; summarize such fixes as a stability/reliability improvement at most once.
+- Never claim a feature or fix that is not supported by the commits and diff below.
+
+Commits:
+$commitLog
+
+Diff stat:
+$diffStat
+
+Diff (may be truncated):
+$diff
+"@
+
+    try {
+        $body = @{
+            model      = $Model
+            max_tokens = 1024
+            system     = $systemPrompt
+            messages   = @(@{ role = "user"; content = $userPrompt })
+        } | ConvertTo-Json -Depth 6
+        $response = Invoke-RestMethod -Uri "https://api.anthropic.com/v1/messages" -Method Post -Body $body -Headers @{
+            "x-api-key"         = $env:ANTHROPIC_API_KEY
+            "anthropic-version" = "2023-06-01"
+            "content-type"      = "application/json"
+        }
+    }
+    catch {
+        Write-Skip "Anthropic API call failed: $($_.Exception.Message)"
+        exit 0
+    }
+
+    $text = ($response.content | Where-Object { $_.type -eq "text" } | ForEach-Object { $_.text }) -join "`n"
+    $bullets = @($text -split "\r?\n" |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_ -match "^[\*\-]\s+\S" } |
+        ForEach-Object { "* " + ($_ -replace "^[\*\-]\s+", "") })
+
+    if ($bullets.Count -lt 1 -or $bullets.Count -gt 8) {
+        Write-Skip "Model returned $($bullets.Count) bullet lines, expected 1-8"
+        exit 0
+    }
+}
+
+$highlightsBlock = "### Highlights`n`n" + ($bullets -join "`n")
+$insertPos = $headingMatch.Index + $headingMatch.Length
+$newChangelog = $changelog.Substring(0, $insertPos) + "`n`n`n" + $highlightsBlock + $changelog.Substring($insertPos)
+Set-Content -Path $ChangelogFile -Value $newChangelog -NoNewline
+
+Write-Host "Inserted $($bullets.Count) highlight bullet(s) for $version into $($ChangelogFile):"
+$bullets | ForEach-Object { Write-Host "  $_" }

--- a/scripts/update-installer-manifest.ps1
+++ b/scripts/update-installer-manifest.ps1
@@ -35,9 +35,20 @@ $changelogMatch = [regex]::Match($changelogContent, $versionPattern, [System.Tex
 $changelogEntries = @()
 if ($changelogMatch.Success) {
     $versionChangelog = $changelogMatch.Groups[1].Value
-    # Extract bullet points from Features and Bug Fixes sections
+
+    # Prefer the curated "### Highlights" section (user-facing bullets added on
+    # the release PR by generate-release-highlights.ps1). Fall back to the raw
+    # Features/Bug Fixes bullets when no Highlights section exists.
+    $highlightsMatch = [regex]::Match($versionChangelog, "### Highlights\s*\n(.*?)(?=\n###|\n## |$)", [System.Text.RegularExpressions.RegexOptions]::Singleline)
+    $bulletSource = $versionChangelog
+    if ($highlightsMatch.Success) {
+        Write-Host "Using curated Highlights section for changelog entries"
+        $bulletSource = $highlightsMatch.Groups[1].Value
+    }
+
+    # Extract bullet points
     $bulletPattern = "^\s*\*\s+(.+?)$"
-    $matches = [regex]::Matches($versionChangelog, $bulletPattern, [System.Text.RegularExpressions.RegexOptions]::Multiline)
+    $matches = [regex]::Matches($bulletSource, $bulletPattern, [System.Text.RegularExpressions.RegexOptions]::Multiline)
 
     foreach ($match in $matches) {
         $line = $match.Groups[1].Value.Trim()
@@ -49,12 +60,6 @@ if ($changelogMatch.Success) {
             $changelogEntries += $line
         }
     }
-}
-
-# Marketing note placeholder (leave empty to skip)
-$marketingNote = ""
-if ($marketingNote) {
-    $changelogEntries = @($marketingNote) + $changelogEntries
 }
 
 # If no changelog entries found, add a generic one


### PR DESCRIPTION
## What

Playnite shows users the `Changelog` entries from `installer_manifest.yaml`, which until now were raw conventional-commit subjects ("fix(sync): apply library snapshot diff before committing hash baseline"). This PR adds an AI-drafted, human-reviewed "Highlights" layer between commits and what players read.

## How it works

1. **`.github/workflows/release-highlights.yml`** runs on release-please PR branches (`release-please--*`, same-repo only). It calls `scripts/generate-release-highlights.ps1`, which sends the commits **and diff** since the last release tag to the Anthropic API (`claude-sonnet-5`) and inserts 2-6 player-friendly bullets as a `### Highlights` section under the new version heading in CHANGELOG.md, committed back to the release PR.
2. **The release PR is the review gate** - edit the bullets there like any other diff; whatever is merged is what ships.
3. **`scripts/update-installer-manifest.ps1`** now prefers the `### Highlights` bullets for `installer_manifest.yaml`; when absent it falls back to the raw feat/fix bullets (so a failed generation never blocks a release). The hardcoded `$marketingNote` placeholder is removed.

## Safety / robustness

- Idempotent: no-ops when Highlights already exist (also breaks the push-synchronize workflow loop).
- Best-effort: missing `ANTHROPIC_API_KEY`, API failure, or malformed output warns and exits 0.
- Fork-safe: `pull_request` trigger (fork runs get no secrets) plus an explicit same-repo guard.

## Tested

- Dry-run insertion produces correctly formatted markdown; second run no-ops.
- Manifest script end-to-end (with the real powershell-yaml module): uses only curated bullets when Highlights present, falls back cleanly when absent.
- Missing-API-key path warns and exits 0.

Requires the `ANTHROPIC_API_KEY` repo secret (already added).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated generation of user-facing release highlights for upcoming versions.
  * Release highlights are added to the changelog and can be reviewed or edited during the release process.
  * Installer release notes now prioritize curated highlights, with existing changelog sections used as a fallback.

* **Bug Fixes**
  * Improved handling when release highlights are unavailable, preventing release updates from being blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->