### PR TITLE
feat(theme): embeddable dashboard control for Fullscreen/Desktop themes (#74)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,12 @@ GsPlugin (entry point, IDisposable)
 - Auto-refreshes the dashboard token when the sidebar becomes visible after 8+ minutes (tokens have a 10-minute TTL).
 - Handles `gs:refresh-token` postMessage from the frontend for manual retry when the session expires.
 
+### Theme Integration (Desktop & Fullscreen)
+- The dashboard is exposed as a theme-embeddable custom element so it works in **Fullscreen mode**, which has no sidebar. The sidebar (`GetSidebarItems`) and the Extensions menu (`GetMainMenuItems`) are Desktop-only surfaces.
+- Registered in the `GsPlugin` constructor via `AddCustomElementSupport(SourceName = "GameScrobbler", ElementList = ["Dashboard"])`. Theme developers embed it with `<ContentControl x:Name="GameScrobbler_Dashboard" />` in either a Desktop or Fullscreen theme.
+- `GsPlugin.GetGameViewControl(GetGameViewControlArgs)` returns a fresh `MySidebarView(_apiClient)` when `args.Name == "Dashboard"`; returns `null` for unknown names or when opted out. `args.Mode` distinguishes `Desktop`/`Fullscreen` if mode-specific controls are ever needed. The same WebView2 dashboard is reused for all surfaces.
+- The returned `MySidebarView` self-disposes on `Unloaded`, so Playnite creating/destroying the control on theme reloads or view changes is safe.
+
 ### Achievement Provider Architecture
 Achievement data comes from two optional addons via an aggregator pattern:
 - `IAchievementProvider` — common interface (`GetCounts`, `GetAchievements`, `IsInstalled`)

--- a/GsPlugin.cs
+++ b/GsPlugin.cs
@@ -124,6 +124,15 @@ namespace GsPlugin {
 
             // Initialize server notification service
             _notificationService = new GsNotificationService(api, _apiClient, Id);
+
+            // Expose the dashboard as a theme-embeddable control so theme developers can place
+            // it inside their Desktop or Fullscreen themes. Playnite renders a control named
+            // "GameScrobbler_Dashboard" in theme XAML by calling GetGameViewControl below.
+            // This is how the plugin becomes usable in Fullscreen mode, which has no sidebar.
+            AddCustomElementSupport(new AddCustomElementSupportArgs {
+                SourceName = "GameScrobbler",
+                ElementList = new List<string> { "Dashboard" }
+            });
         }
 
         /// <summary>
@@ -367,6 +376,26 @@ namespace GsPlugin {
         /// <returns>A UserControl that represents the settings view.</returns>
         public override UserControl GetSettingsView(bool firstRunSettings) {
             return new GsPluginSettingsView();
+        }
+
+        /// <summary>
+        /// Returns a theme-embeddable control by name. Playnite calls this when a theme
+        /// (Desktop or Fullscreen) contains a control named "GameScrobbler_&lt;Name&gt;", which was
+        /// registered via <see cref="Plugin.AddCustomElementSupport"/> in the constructor.
+        ///
+        /// This is the integration point that makes the plugin usable in Fullscreen mode:
+        /// Fullscreen has no sidebar, so theme developers place the dashboard control themselves.
+        /// </summary>
+        /// <param name="args">Requested element name and the current application mode.</param>
+        /// <returns>The requested control, or null when unknown/opted out.</returns>
+        public override Control GetGameViewControl(GetGameViewControlArgs args) {
+            if (GsDataManager.IsOptedOut) {
+                return null;
+            }
+            if (args.Name == "Dashboard") {
+                return new MySidebarView(_apiClient);
+            }
+            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
## What & why

Fixes the Fullscreen-mode gap raised in #74. Playnite's **Fullscreen mode** has no sidebar and no Extensions menu, so the Game Scrobbler dashboard was previously only reachable in Desktop mode. This makes the dashboard a **theme-embeddable custom element** so theme developers can place it in either a Desktop or a Fullscreen theme.

## How

- Register the element in the plugin constructor:
  ```csharp
  AddCustomElementSupport(new AddCustomElementSupportArgs {
      SourceName = "GameScrobbler",
      ElementList = new List<string> { "Dashboard" }
  });
  ```
- Override `GetGameViewControl` to return the existing `MySidebarView` when the theme requests `Dashboard`; returns `null` for unknown names or when the user has opted out.

Theme developers embed it with:
```xml
<ContentControl x:Name="GameScrobbler_Dashboard" />
```
`args.Mode` (`Desktop`/`Fullscreen`) is available if a mode-specific control is ever needed; today the same WebView2 dashboard serves both. `MySidebarView` already self-disposes on `Unloaded`, so Playnite creating/destroying it across theme reloads is safe.

## Scope / follow-up

This is **phase 1 — the enabler**. It surfaces the *full* dashboard as an embedded WebView2, which is the minimum viable integration. It is intentionally **not** a programmatic, natively-themeable data API — theme authors can position/size the control but can't restyle its internals or bind individual data points (e.g. render just the roast text or the detective board in their own theme's visual language).

The custom-element mechanism added here is the required foundation for a richer phase 2 regardless of direction (more granular native controls and/or theme data-binding via `AddSettingsSupport`). Tracking that separately — see discussion on #74.

## Testing

- Release build via VS MSBuild: succeeded (only pre-existing, unrelated `MSB3277` warnings in the test project).
- `dotnet test`: **314 passed, 0 failed**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for embedding the dashboard in compatible Playnite themes, including fullscreen.
  * Registered the dashboard as a theme-embeddable custom element and reused it across the sidebar, extensions menu, and fullscreen surfaces.

* **Documentation**
  * Updated guidance on theme integration: supported hosting surfaces, how the dashboard view is resolved, and safe behavior during theme reloads (including opt-out behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->