### PR TITLE
fix(hooks): run pre-commit format check under a capable .NET SDK

### DIFF
--- a/GsPlugin.cs
+++ b/GsPlugin.cs
@@ -66,6 +66,12 @@ namespace GsPlugin {
         /// </summary>
         private readonly object _timerLock = new object();
         /// <summary>
+        /// Serializes the install-token registration flow so startup (EnsureInstallTokenAsync)
+        /// and on-demand callers (EnsureInstallTokenReadyAsync, e.g. the "Delete My Data"
+        /// button) cannot register concurrently and double-register the install.
+        /// </summary>
+        private readonly SemaphoreSlim _installTokenGate = new SemaphoreSlim(1, 1);
+        /// <summary>
         /// Unique identifier for the plugin itself.
         /// </summary>
         public override Guid Id { get; } = Guid.Parse("32975fed-6915-4dd3-a230-030cdc5265ae");
@@ -497,6 +503,30 @@ namespace GsPlugin {
                 return;
             }
 
+            // Serialize the entire registration + conflict-recovery sequence. Startup and
+            // on-demand callers can otherwise enter concurrently with an empty token and both
+            // register, producing a 409 and a RotateInstallId() that races the in-flight
+            // registration. The gate is held across registration, token storage, rotation, and retry.
+            await _installTokenGate.WaitAsync();
+            try {
+                // Re-check under the gate: a concurrent caller may have stored a token while we
+                // waited, making our registration redundant.
+                if (!string.IsNullOrEmpty(GsDataManager.Data.InstallToken)) {
+                    return;
+                }
+                await EnsureInstallTokenCoreAsync();
+            }
+            finally {
+                _installTokenGate.Release();
+            }
+        }
+
+        /// <summary>
+        /// Performs the actual token registration and 409 rotation-recovery. Always invoked
+        /// under <see cref="_installTokenGate"/> by <see cref="EnsureInstallTokenAsync"/>, so
+        /// concurrent startup and on-demand callers run one at a time.
+        /// </summary>
+        private async Task EnsureInstallTokenCoreAsync() {
             var installId = GsDataManager.Data.InstallID;
             if (string.IsNullOrEmpty(installId)) {
                 _logger.Warn("EnsureInstallTokenAsync: no InstallID available, skipping registration");
@@ -660,6 +690,13 @@ namespace GsPlugin {
                 }
                 catch (Exception ex) {
                     _logger.Error(ex, "Error closing Sentry");
+                }
+
+                try {
+                    _installTokenGate.Dispose();
+                }
+                catch (Exception ex) {
+                    _logger.Error(ex, "Error disposing install-token gate");
                 }
 
                 _apiClient = null;

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -4,8 +4,10 @@
 
 # Check if we're on Windows and use the appropriate script
 if [ "$OS" = "Windows_NT" ] || command -v cmd.exe >/dev/null 2>&1; then
-    # Windows environment - use PowerShell script
-    powershell.exe -ExecutionPolicy Bypass -File .git/hooks/pre-commit.ps1
+    # Windows environment - use PowerShell script.
+    # Resolve the .ps1 next to this hook via $0 so it works from linked git
+    # worktrees too (there .git is a file, so a hardcoded .git/hooks path fails).
+    powershell.exe -ExecutionPolicy Bypass -File "$(dirname "$0")/pre-commit.ps1"
     exit $?
 else
     # Unix/Linux environment
@@ -17,10 +19,31 @@ else
         exit 1
     fi
 
-    # Verify formatting without modifying files
-    dotnet format ./GsPlugin.sln --verify-no-changes 2>&1
+    # Collect staged C#/VB files (added, copied, modified).
+    staged=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(cs|vb)$')
+    if [ -z "$staged" ]; then
+        echo "No C# files to format."
+        exit 0
+    fi
 
-    if [ $? -ne 0 ]; then
+    # Verify formatting without modifying files. The solution contains an
+    # old-style WPF .csproj that dotnet format can only load through a .NET
+    # Framework build host (BuildHost-net472). That build host is a Windows
+    # executable, so full formatting cannot be verified on Linux/macOS -- the
+    # authoritative check runs on Windows via the PowerShell branch above.
+    output=$(dotnet format ./GsPlugin.sln --verify-no-changes 2>&1)
+    status=$?
+
+    if echo "$output" | grep -qE 'Unhandled exception|build host could not be found|TypeInitializationException'; then
+        echo ""
+        echo "WARNING: Cannot verify formatting on this platform (needs the Windows"
+        echo "         .NET Framework build host). Run the check on Windows, or run"
+        echo "         'powershell -File scripts/format-code.ps1' before committing."
+        exit 0
+    fi
+
+    if [ $status -ne 0 ]; then
+        echo "$output"
         echo ""
         echo "ERROR: Code formatting issues detected!"
         echo "Run 'powershell -File scripts/format-code.ps1' to fix formatting, then stage and commit again."

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -19,8 +19,8 @@ else
         exit 1
     fi
 
-    # Collect staged C#/VB files (added, copied, modified).
-    staged=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(cs|vb)$')
+    # Collect staged C#/VB files (added, copied, modified, renamed).
+    staged=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(cs|vb)$')
     if [ -z "$staged" ]; then
         echo "No C# files to format."
         exit 0

--- a/hooks/pre-commit.ps1
+++ b/hooks/pre-commit.ps1
@@ -13,8 +13,8 @@ if ($LASTEXITCODE -ne 0) {
 
 Write-Host "Using .NET SDK version: $dotnetVersion" -ForegroundColor Green
 
-# Get list of staged C# files
-$stagedFiles = @(git diff --cached --name-only --diff-filter=ACM | Where-Object { $_ -match '\.(cs|vb)$' })
+# Get list of staged C# files (added, copied, modified, renamed)
+$stagedFiles = @(git diff --cached --name-only --diff-filter=ACMR | Where-Object { $_ -match '\.(cs|vb)$' })
 
 if ($stagedFiles.Count -eq 0) {
     Write-Host "No C# files to format." -ForegroundColor Green
@@ -23,6 +23,24 @@ if ($stagedFiles.Count -eq 0) {
 
 Write-Host "Found $($stagedFiles.Count) C# file(s) to check:" -ForegroundColor Cyan
 $stagedFiles | ForEach-Object { Write-Host "  - $_" -ForegroundColor Gray }
+
+# dotnet format runs against the working tree, so a staged file whose working-tree
+# content differs from its staged content (partially staged, or staged then edited
+# again) would be validated against bytes that are not what gets committed. Reject
+# those files so the pass/fail decision matches exactly what will be committed.
+$unstagedCs = @(git diff --name-only | Where-Object { $_ -match '\.(cs|vb)$' })
+$partiallyStaged = @($stagedFiles | Where-Object { $unstagedCs -contains $_ })
+if ($partiallyStaged.Count -gt 0) {
+    Write-Host "" -ForegroundColor White
+    Write-Host "ERROR: These staged C#/VB files also have unstaged changes:" -ForegroundColor Red
+    $partiallyStaged | ForEach-Object { Write-Host "  - $_" -ForegroundColor Gray }
+    Write-Host "" -ForegroundColor White
+    Write-Host "The format check runs against the working tree, so its result would not" -ForegroundColor Yellow
+    Write-Host "match what gets committed. Stage them fully (git add) or unstage them," -ForegroundColor Yellow
+    Write-Host "then commit again." -ForegroundColor Yellow
+    Write-Host "" -ForegroundColor White
+    exit 1
+}
 
 # The solution's old-style WPF .csproj can only be loaded by "dotnet format"
 # through a .NET Framework build host, which the repo-pinned .NET 8 SDK does not
@@ -86,6 +104,26 @@ if ($offending) {
     Write-Host "Then review the changes, stage them, and commit again." -ForegroundColor Yellow
     Write-Host "" -ForegroundColor White
     exit 1
+}
+
+# No staged file was flagged. A non-zero formatter exit is safe to ignore only
+# when it is fully explained by per-file diagnostics in files that are NOT staged
+# (pre-existing debt elsewhere). Fail on anything else -- diagnostics that do not
+# parse to a file, or a non-zero exit with no diagnostics at all -- rather than
+# passing an unclassified failure.
+if ($result.ExitCode -ne 0) {
+    $errorLines = @($result.Output | Where-Object { $_ -match ':\s+error ' })
+    $unclassified = @($errorLines | Where-Object { $_ -notmatch '^.+?\(\d+,\d+\):\s+error ' })
+    if ($unclassified.Count -gt 0 -or $errorLines.Count -eq 0) {
+        Write-Host "" -ForegroundColor White
+        Write-Host "ERROR: dotnet format failed (exit $($result.ExitCode)) for reasons not" -ForegroundColor Red
+        Write-Host "limited to unstaged files:" -ForegroundColor Red
+        Write-Host "" -ForegroundColor White
+        $detail = if ($unclassified.Count -gt 0) { $unclassified } else { $result.Output }
+        Write-Host ($detail -join [Environment]::NewLine) -ForegroundColor Gray
+        Write-Host "" -ForegroundColor White
+        exit 1
+    }
 }
 
 Write-Host "Code formatting check passed!" -ForegroundColor Green

--- a/hooks/pre-commit.ps1
+++ b/hooks/pre-commit.ps1
@@ -14,7 +14,7 @@ if ($LASTEXITCODE -ne 0) {
 Write-Host "Using .NET SDK version: $dotnetVersion" -ForegroundColor Green
 
 # Get list of staged C# files
-$stagedFiles = git diff --cached --name-only --diff-filter=ACM | Where-Object { $_ -match '\.(cs|vb)$' }
+$stagedFiles = @(git diff --cached --name-only --diff-filter=ACM | Where-Object { $_ -match '\.(cs|vb)$' })
 
 if ($stagedFiles.Count -eq 0) {
     Write-Host "No C# files to format." -ForegroundColor Green
@@ -24,34 +24,68 @@ if ($stagedFiles.Count -eq 0) {
 Write-Host "Found $($stagedFiles.Count) C# file(s) to check:" -ForegroundColor Cyan
 $stagedFiles | ForEach-Object { Write-Host "  - $_" -ForegroundColor Gray }
 
-# Run dotnet format in verify mode -does not modify files.
-# The solution contains an old-style WPF .csproj that requires a .NET Framework
-# build host (BuildHost-net472). When that host is missing or incompatible the
-# workspace loader throws an unhandled exception instead of reporting formatting
-# violations. We distinguish this infrastructure crash from a real formatting
-# failure by inspecting the output for known crash signatures.
-Write-Host "Checking code formatting..." -ForegroundColor Cyan
-$formatResult = dotnet format GsPlugin.sln --verify-no-changes --verbosity quiet 2>&1
-$formatExitCode = $LASTEXITCODE
+# The solution's old-style WPF .csproj can only be loaded by "dotnet format"
+# through a .NET Framework build host, which the repo-pinned .NET 8 SDK does not
+# ship. format-sdk.ps1 runs the real "dotnet format" under the newest installed
+# SDK that has a working build host, leaving the repo's SDK pin untouched.
+# Git runs hooks from the repository root, so this working-tree path resolves.
+. ./scripts/format-sdk.ps1
 
-if ($formatExitCode -ne 0) {
-    $resultText = $formatResult | Out-String
-    if ($resultText -match "Unhandled exception" -or $resultText -match "TypeInitializationException" -or $resultText -match "BuildHost") {
-        Write-Host "Warning: dotnet format crashed (MSBuild workspace loader issue)." -ForegroundColor Yellow
-        Write-Host "Skipping format check - run 'scripts/format-code.ps1' manually if needed." -ForegroundColor Yellow
-    } else {
-        Write-Host "" -ForegroundColor White
-        Write-Host "============================================" -ForegroundColor Red
-        Write-Host "  CODE FORMATTING ISSUES DETECTED" -ForegroundColor Red
-        Write-Host "============================================" -ForegroundColor Red
-        Write-Host "" -ForegroundColor White
-        Write-Host "Please fix formatting before committing:" -ForegroundColor Yellow
-        Write-Host "  powershell -ExecutionPolicy Bypass -File scripts/format-code.ps1" -ForegroundColor Gray
-        Write-Host "" -ForegroundColor White
-        Write-Host "Then review the changes, stage them, and commit again." -ForegroundColor Yellow
-        Write-Host "" -ForegroundColor White
-        exit 1
+$sdk = Get-GsFormatSdk
+if (-not $sdk) {
+    Write-Host "" -ForegroundColor White
+    Write-Host "ERROR: No installed .NET SDK can format this solution." -ForegroundColor Red
+    Write-Host "dotnet format needs a .NET Framework build host (BuildHost-net472)" -ForegroundColor Yellow
+    Write-Host "that the pinned .NET 8 SDK does not ship. Install the .NET 10 SDK:" -ForegroundColor Yellow
+    Write-Host "  https://dotnet.microsoft.com/download/dotnet/10.0" -ForegroundColor Gray
+    Write-Host "" -ForegroundColor White
+    exit 1
+}
+
+Write-Host "Checking code formatting (dotnet format via SDK $sdk)..." -ForegroundColor Cyan
+$repoRoot = (Get-Location).Path
+$result = Invoke-GsDotnetFormat -RepoRoot $repoRoot -SdkVersion $sdk -ExtraArgs @('--verify-no-changes', '--verbosity', 'quiet')
+
+# A capable SDK should not crash, but fail loudly rather than skip if it does.
+$joined = ($result.Output -join "`n")
+if ($joined -match 'Unhandled exception|build host could not be found|TypeInitializationException') {
+    Write-Host "" -ForegroundColor White
+    Write-Host "ERROR: dotnet format could not load the solution (build host failure)." -ForegroundColor Red
+    Write-Host "Install the .NET 10 SDK, then commit again:" -ForegroundColor Yellow
+    Write-Host "  https://dotnet.microsoft.com/download/dotnet/10.0" -ForegroundColor Gray
+    Write-Host "" -ForegroundColor White
+    exit 1
+}
+
+# dotnet format verifies the whole solution; restrict the pass/fail decision to
+# the staged files so pre-existing formatting debt elsewhere does not block this
+# commit. Match each "<path>(line,col): error RULE:" line against the staged set.
+$stagedSet = @{}
+foreach ($f in $stagedFiles) { $stagedSet[($f -replace '\\', '/').ToLowerInvariant()] = $true }
+$repoPrefix = (($repoRoot -replace '\\', '/').ToLowerInvariant().TrimEnd('/')) + '/'
+
+$offending = foreach ($line in $result.Output) {
+    if ($line -match '^(?<path>.+?)\(\d+,\d+\):\s+error ') {
+        $p = ($Matches['path'] -replace '\\', '/').ToLowerInvariant()
+        if ($p.StartsWith($repoPrefix)) { $p = $p.Substring($repoPrefix.Length) }
+        if ($stagedSet.ContainsKey($p)) { $line }
     }
+}
+
+if ($offending) {
+    Write-Host "" -ForegroundColor White
+    Write-Host "============================================" -ForegroundColor Red
+    Write-Host "  CODE FORMATTING ISSUES DETECTED" -ForegroundColor Red
+    Write-Host "============================================" -ForegroundColor Red
+    Write-Host "" -ForegroundColor White
+    Write-Host ($offending -join [Environment]::NewLine) -ForegroundColor Gray
+    Write-Host "" -ForegroundColor White
+    Write-Host "Please fix formatting before committing:" -ForegroundColor Yellow
+    Write-Host "  powershell -ExecutionPolicy Bypass -File scripts/format-code.ps1" -ForegroundColor Gray
+    Write-Host "" -ForegroundColor White
+    Write-Host "Then review the changes, stage them, and commit again." -ForegroundColor Yellow
+    Write-Host "" -ForegroundColor White
+    exit 1
 }
 
 Write-Host "Code formatting check passed!" -ForegroundColor Green

--- a/scripts/format-code.ps1
+++ b/scripts/format-code.ps1
@@ -12,33 +12,47 @@ if ($LASTEXITCODE -ne 0) {
 
 Write-Host "Using .NET SDK version: $dotnetVersion" -ForegroundColor Green
 
-# Get all C# files in the project
-$csFiles = Get-ChildItem -Recurse -Include "*.cs" -Exclude "**/bin/**", "**/obj/**", "**/packages/**" | Where-Object { $_.FullName -notmatch "(bin|obj|packages)" }
+# The solution's old-style WPF .csproj can only be loaded by "dotnet format"
+# through a .NET Framework build host, which the repo-pinned .NET 8 SDK does not
+# ship. format-sdk.ps1 runs the real "dotnet format" under the newest installed
+# SDK that has a working build host, leaving the repo's SDK pin untouched.
+. "$PSScriptRoot/format-sdk.ps1"
 
-if ($csFiles.Count -eq 0) {
-    Write-Host "No C# files found to format." -ForegroundColor Yellow
-    exit 0
+$sdk = Get-GsFormatSdk
+if (-not $sdk) {
+    Write-Host "Error: No installed .NET SDK can format this solution." -ForegroundColor Red
+    Write-Host "dotnet format needs a .NET Framework build host (BuildHost-net472) that the" -ForegroundColor Yellow
+    Write-Host "pinned .NET 8 SDK does not ship. Install the .NET 10 SDK:" -ForegroundColor Yellow
+    Write-Host "  https://dotnet.microsoft.com/download/dotnet/10.0" -ForegroundColor Gray
+    exit 1
 }
 
-Write-Host "Found $($csFiles.Count) C# files to format" -ForegroundColor Green
+$repoRoot = Split-Path -Parent $PSScriptRoot
 
-# Run dotnet format on the solution with progress indication
-Write-Host "Running 'dotnet format .\GsPlugin.sln'..." -ForegroundColor Cyan
+# Run dotnet format (fix mode -no --verify-no-changes) on the whole solution.
+Write-Host "Running 'dotnet format GsPlugin.sln' via SDK $sdk..." -ForegroundColor Cyan
 Write-Host "This may take a moment..." -ForegroundColor Gray
 
 try {
-    # Run the format command and capture output
-    $output = dotnet format .\GsPlugin.sln --verbosity normal 2>&1
-    
-    if ($LASTEXITCODE -eq 0) {
+    $result = Invoke-GsDotnetFormat -RepoRoot $repoRoot -SdkVersion $sdk -ExtraArgs @('--verbosity', 'normal')
+    $output = $result.Output
+
+    $joined = ($output -join "`n")
+    if ($joined -match 'Unhandled exception|build host could not be found|TypeInitializationException') {
+        Write-Host "Error: dotnet format could not load the solution (build host failure)." -ForegroundColor Red
+        Write-Host "Install the .NET 10 SDK, then try again." -ForegroundColor Yellow
+        exit 1
+    }
+
+    if ($result.ExitCode -eq 0) {
         Write-Host "Code formatting completed successfully!" -ForegroundColor Green
         if ($output) {
             Write-Host "Output:" -ForegroundColor Gray
-            Write-Host $output -ForegroundColor Gray
+            Write-Host ($output -join [Environment]::NewLine) -ForegroundColor Gray
         }
     } else {
         Write-Host "Code formatting completed with warnings:" -ForegroundColor Yellow
-        Write-Host $output -ForegroundColor Yellow
+        Write-Host ($output -join [Environment]::NewLine) -ForegroundColor Yellow
     }
 } catch {
     Write-Host "Error running dotnet format: $($_.Exception.Message)" -ForegroundColor Red

--- a/scripts/format-code.ps1
+++ b/scripts/format-code.ps1
@@ -51,8 +51,9 @@ try {
             Write-Host ($output -join [Environment]::NewLine) -ForegroundColor Gray
         }
     } else {
-        Write-Host "Code formatting completed with warnings:" -ForegroundColor Yellow
+        Write-Host "Code formatting failed (dotnet format exit $($result.ExitCode)):" -ForegroundColor Red
         Write-Host ($output -join [Environment]::NewLine) -ForegroundColor Yellow
+        exit 1
     }
 } catch {
     Write-Host "Error running dotnet format: $($_.Exception.Message)" -ForegroundColor Red

--- a/scripts/format-sdk.ps1
+++ b/scripts/format-sdk.ps1
@@ -1,0 +1,86 @@
+# Shared helper for running "dotnet format" on this solution.
+#
+# The solution includes an old-style (non-SDK) WPF .csproj that targets .NET
+# Framework. "dotnet format" can only load such a project through a .NET
+# Framework build host (BuildHost-net472). The repo pins the .NET 8 SDK via
+# global.json for reproducible builds/tests, but the 8.x SDK's bundled
+# dotnet-format ships no working net472 build host, so a plain "dotnet format"
+# crashes with "The build host could not be found". The .NET 10 SDK's build host
+# loads the project correctly.
+#
+# These helpers locate the newest installed SDK that has a working build host and
+# run "dotnet format" under it -- via a throwaway global.json in a temp folder --
+# so formatting works without changing the SDK the repo pins for builds/tests.
+
+function Get-GsFormatSdk {
+    # Returns the newest installed SDK version whose dotnet-format ships a .NET
+    # Framework build host, preferring major version >= 10 (the 9.x host is
+    # present but crashes loading this WPF project). Returns $null when none
+    # qualifies -- callers should surface a clear "install a newer SDK" message.
+    $sdks = & dotnet --list-sdks 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $sdks) { return $null }
+
+    $candidates = foreach ($line in $sdks) {
+        # Each line looks like: "10.0.302 [C:\Program Files\dotnet\sdk]"
+        if ($line -match '^(?<ver>\S+)\s+\[(?<dir>.+)\]$') {
+            $ver = $Matches['ver']
+            $dir = $Matches['dir']
+            $host472 = Join-Path $dir (Join-Path $ver 'DotnetTools/dotnet-format/BuildHost-net472/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.exe')
+            if (Test-Path -LiteralPath $host472) {
+                [pscustomobject]@{
+                    Version = $ver
+                    Major   = [int]($ver.Split('.')[0])
+                }
+            }
+        }
+    }
+    if (-not $candidates) { return $null }
+
+    # major >= 10 first, then highest version string within that group.
+    $ranked = $candidates | Sort-Object `
+        -Property @{ Expression = { $_.Major -ge 10 }; Descending = $true }, `
+                  @{ Expression = { $_.Version }; Descending = $true }
+    return $ranked[0].Version
+}
+
+function Invoke-GsDotnetFormat {
+    # Runs "dotnet format <solution> <ExtraArgs>" under the given SDK. The SDK is
+    # selected with a throwaway global.json in a temp directory we cd into, so the
+    # repo's own global.json (pinned to .NET 8) is left untouched. Returns a
+    # hashtable @{ ExitCode; Output }, where Output is an array of plain strings
+    # (dotnet's stderr diagnostics are stringified to avoid PowerShell
+    # NativeCommandError noise).
+    param(
+        [Parameter(Mandatory)][string]   $RepoRoot,
+        [Parameter(Mandatory)][string]   $SdkVersion,
+        [string[]]                        $ExtraArgs = @()
+    )
+
+    $sln = Join-Path $RepoRoot 'GsPlugin.sln'
+    $sdkDir = Join-Path ([System.IO.Path]::GetTempPath()) 'gs-playnite-format-sdk'
+    New-Item -ItemType Directory -Force -Path $sdkDir | Out-Null
+
+    $globalJson = @"
+{
+  "sdk": {
+    "version": "$SdkVersion",
+    "rollForward": "disable",
+    "allowPrerelease": true
+  }
+}
+"@
+    [System.IO.File]::WriteAllText((Join-Path $sdkDir 'global.json'), $globalJson)
+
+    Push-Location $sdkDir
+    try {
+        # dotnet writes formatting diagnostics to stderr; with 2>&1 those become
+        # error records. Force Continue (function-local) so stderr does not turn
+        # into a terminating error, and stringify each record to plain text.
+        $ErrorActionPreference = 'Continue'
+        $output = & dotnet format $sln @ExtraArgs 2>&1 | ForEach-Object { "$_" }
+        $code = $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
+    return @{ ExitCode = $code; Output = $output }
+}

--- a/scripts/format-sdk.ps1
+++ b/scripts/format-sdk.ps1
@@ -14,9 +14,10 @@
 
 function Get-GsFormatSdk {
     # Returns the newest installed SDK version whose dotnet-format ships a .NET
-    # Framework build host, preferring major version >= 10 (the 9.x host is
-    # present but crashes loading this WPF project). Returns $null when none
-    # qualifies -- callers should surface a clear "install a newer SDK" message.
+    # Framework build host, requiring major version >= 10. The 8.x SDK ships no
+    # working net472 host and the 9.x host crashes loading this WPF project, so
+    # neither qualifies. Returns $null when none qualifies -- callers should
+    # surface a clear "install a newer SDK" message.
     $sdks = & dotnet --list-sdks 2>$null
     if ($LASTEXITCODE -ne 0 -or -not $sdks) { return $null }
 
@@ -25,22 +26,21 @@ function Get-GsFormatSdk {
         if ($line -match '^(?<ver>\S+)\s+\[(?<dir>.+)\]$') {
             $ver = $Matches['ver']
             $dir = $Matches['dir']
+            $major = [int]($ver.Split('.')[0])
             $host472 = Join-Path $dir (Join-Path $ver 'DotnetTools/dotnet-format/BuildHost-net472/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.exe')
-            if (Test-Path -LiteralPath $host472) {
+            if ($major -ge 10 -and (Test-Path -LiteralPath $host472)) {
                 [pscustomobject]@{
                     Version = $ver
-                    Major   = [int]($ver.Split('.')[0])
+                    # Parse the numeric prefix (drop any -prerelease tag) so
+                    # versions compare semantically: 10.0.10 outranks 10.0.9.
+                    Parsed  = [version](($ver -split '-')[0])
                 }
             }
         }
     }
     if (-not $candidates) { return $null }
 
-    # major >= 10 first, then highest version string within that group.
-    $ranked = $candidates | Sort-Object `
-        -Property @{ Expression = { $_.Major -ge 10 }; Descending = $true }, `
-                  @{ Expression = { $_.Version }; Descending = $true }
-    return $ranked[0].Version
+    return ($candidates | Sort-Object -Property Parsed -Descending | Select-Object -First 1).Version
 }
 
 function Invoke-GsDotnetFormat {


### PR DESCRIPTION
## Problem

The pre-commit hook and `scripts/format-code.ps1` ran `dotnet format` on the solution, but the repo-pinned **.NET 8 SDK** (`global.json`) cannot do that: its bundled formatter ships **no working .NET Framework build host** (`BuildHost-net472.exe` is absent) for the old-style WPF `GsPlugin.csproj`. So `dotnet format` crashed with *"The build host could not be found"*, and the hook caught that crash signature and **silently self-skipped** — formatting was never actually enforced.

Notes from investigation:
- Installing a newer 8.0 SDK does **not** fix it (both 8.0.319 and 8.0.423 lack the host).
- The **9.x** build host is present but crashes loading this WPF project (`XMakeElements` `TypeInitializationException`).
- The **10.x** build host loads it correctly and runs the full formatter.

## Fix

- **New `scripts/format-sdk.ps1`** — locates the newest installed SDK whose `dotnet-format` has a working build host (prefers major ≥ 10) and runs `dotnet format` under it via a throwaway `global.json` in a temp dir. The repo's 8.0 pin for builds/tests is left untouched.
- **`hooks/pre-commit.ps1`** — runs the real full formatter (whitespace **+** code-style), then scopes the pass/fail decision to the staged files by filtering the output (solution-mode `--include` proved unreliable). Fails loudly with install guidance if no capable SDK is present — never silently skips.
- **`scripts/format-code.ps1`** — fixes the whole solution the same way.
- **`hooks/pre-commit`** (sh wrapper) — resolves its `.ps1` via `$0` so it works from linked git worktrees (where `.git` is a file); the Unix branch warns clearly on platforms that can't run the Windows build host instead of pretending to check.

## Verification

- Clean staged file → passes (exit 0).
- Genuinely misformatted staged file → fails (exit 1) with the exact offending lines.
- Runs full formatting via SDK 10.0.302 in ~11s; `dotnet --version` in-repo stays 8.0.423.
- Scoping confirmed: pre-existing formatting debt in unstaged files does not block unrelated commits.

## Note for reviewers

There is pre-existing formatting debt in 8 files not touched here (e.g. `Infrastructure/GsAtomicFile.cs`, `Models/GsData.cs`). Because the hook scopes to staged files, they only need fixing when someone edits them — `scripts/format-code.ps1` cleans them all up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of server install-token registration when multiple operations occur simultaneously.
  * Enhanced cleanup of registration resources during shutdown.

* **Developer Experience**
  * Improved formatting checks for linked worktrees and non-Windows environments.
  * Formatting verification now focuses on staged C#/VB files and provides clearer guidance for missing SDK support.
  * Added automatic selection of a compatible .NET SDK for formatting commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->