### PR TITLE
fix(achievements): prefer live plugin over stale on-disk provider data

### DIFF
--- a/Api/Dtos.cs
+++ b/Api/Dtos.cs
@@ -342,6 +342,22 @@ namespace GsPlugin.Api {
         public bool success { get; set; }
         public string message { get; set; }
         public bool rateLimited { get; set; }
+
+        /// <summary>
+        /// Server resolved the install as already opted out (HTTP 403). The data is
+        /// already gone — the client should sync its local opt-out state rather than
+        /// treat this as a retryable failure.
+        /// </summary>
+        [JsonIgnore]
+        public bool alreadyOptedOut { get; set; }
+
+        /// <summary>
+        /// Server rejected the install token (HTTP 401). The stored token does not
+        /// resolve to an install, so retrying with the same token cannot succeed —
+        /// the user needs to reconnect rather than keep hitting the same wall.
+        /// </summary>
+        [JsonIgnore]
+        public bool authFailed { get; set; }
     }
 
     public class OptInReq {

--- a/Api/GsApiClient.cs
+++ b/Api/GsApiClient.cs
@@ -743,6 +743,22 @@ namespace GsPlugin.Api {
                     return new DeleteDataRes { success = false, rateLimited = true };
                 }
 
+                // 403 = install already opted out server-side (data already deleted, or
+                // removed via a linked web-account deletion). Retrying can never succeed;
+                // signal the caller to sync local opt-out state instead of looping on a
+                // generic "failed" message.
+                if ((int)response.StatusCode == 403) {
+                    _logger.Warn("RequestDeleteMyData: install already opted out (403)");
+                    return new DeleteDataRes { success = false, alreadyOptedOut = true };
+                }
+
+                // 401 = stored token does not resolve to an install. Retrying with the
+                // same token is futile — surface a distinct "reconnect" signal.
+                if ((int)response.StatusCode == 401) {
+                    _logger.Warn("RequestDeleteMyData: install token rejected (401)");
+                    return new DeleteDataRes { success = false, authFailed = true };
+                }
+
                 if (!response.IsSuccessStatusCode) {
                     _logger.Warn($"RequestDeleteMyData returned {(int)response.StatusCode}");
                     return new DeleteDataRes { success = false };

--- a/GsPlugin.Tests/AccountLinkingResponseTests.cs
+++ b/GsPlugin.Tests/AccountLinkingResponseTests.cs
@@ -1,0 +1,45 @@
+using Xunit;
+using GsPlugin.Models;
+using GsPlugin.Services;
+
+namespace GsPlugin.Tests {
+    /// <summary>
+    /// Tests for <see cref="GsAccountLinkingService.IsLinkedUserId"/> — the guard that prevents a
+    /// verify response which succeeds but resolves to the "not_linked" sentinel (or an empty user id)
+    /// from being reported as a successful link. Without it the settings UI showed
+    /// "Successfully linked!" while the connection status stayed "Disconnected" and the website's
+    /// linking page kept polling "not linked" (issue #54).
+    /// </summary>
+    public class AccountLinkingResponseTests {
+        [Fact]
+        public void RealUserId_IsLinked() {
+            Assert.True(GsAccountLinkingService.IsLinkedUserId("user_abc123"));
+        }
+
+        [Fact]
+        public void NotLinkedSentinel_IsNotLinked() {
+            Assert.False(GsAccountLinkingService.IsLinkedUserId(GsData.NotLinkedValue));
+        }
+
+        [Fact]
+        public void LiteralNotLinkedString_IsNotLinked() {
+            // Guards against the sentinel value drifting away from the literal the server sends.
+            Assert.False(GsAccountLinkingService.IsLinkedUserId("not_linked"));
+        }
+
+        [Fact]
+        public void Null_IsNotLinked() {
+            Assert.False(GsAccountLinkingService.IsLinkedUserId(null));
+        }
+
+        [Fact]
+        public void Empty_IsNotLinked() {
+            Assert.False(GsAccountLinkingService.IsLinkedUserId(""));
+        }
+
+        [Fact]
+        public void Whitespace_IsNotLinked() {
+            Assert.False(GsAccountLinkingService.IsLinkedUserId("   "));
+        }
+    }
+}

--- a/GsPlugin.Tests/AchievementProviderTests.cs
+++ b/GsPlugin.Tests/AchievementProviderTests.cs
@@ -10,6 +10,7 @@ namespace GsPlugin.Tests {
     /// </summary>
     internal class StubAchievementProvider : IAchievementProvider {
         public bool IsInstalled { get; set; }
+        public bool IsPluginLoaded { get; set; }
         public string ProviderName { get; set; } = "Stub";
         public string Version { get; set; }
 
@@ -306,6 +307,78 @@ namespace GsPlugin.Tests {
             var agg = new GsAchievementAggregator(p1);
 
             Assert.Null(agg.GetCounts(GameA));
+        }
+
+        [Fact]
+        public void GetAchievements_PrefersLivePluginOverStaleDataOnlyProvider() {
+            // Reproduces issue #66: a leftover SuccessStory data directory (plugin
+            // uninstalled -> IsPluginLoaded false) must not shadow the actually-installed
+            // Playnite Achievements provider, even though SuccessStory is priority 1.
+            var successStory = new StubAchievementProvider {
+                IsInstalled = true,
+                IsPluginLoaded = false,
+                ProviderName = "SuccessStory",
+                Data = { [GameA] = MakeAchievements(1, 30) } // stale
+            };
+            var playniteAch = new StubAchievementProvider {
+                IsInstalled = true,
+                IsPluginLoaded = true,
+                ProviderName = "Playnite Achievements",
+                Data = { [GameA] = MakeAchievements(12, 30) } // fresh
+            };
+            var agg = new GsAchievementAggregator(successStory, playniteAch);
+
+            var (achievements, source) = agg.GetAchievementsWithSource(GameA);
+            Assert.Equal("Playnite Achievements", source);
+            Assert.Equal(12, achievements.Count(a => a.IsUnlocked));
+
+            var counts = agg.GetCounts(GameA);
+            Assert.Equal(12, counts.Value.unlocked);
+        }
+
+        [Fact]
+        public void GetAchievements_UsesDataOnlyProvider_WhenNoLivePluginHasData() {
+            // A data-only provider is still better than nothing: if no live plugin has
+            // data for the game, fall back to the lingering on-disk data.
+            var successStory = new StubAchievementProvider {
+                IsInstalled = true,
+                IsPluginLoaded = false,
+                ProviderName = "SuccessStory",
+                Data = { [GameA] = MakeAchievements(3, 5) }
+            };
+            var playniteAch = new StubAchievementProvider {
+                IsInstalled = true,
+                IsPluginLoaded = true,
+                ProviderName = "Playnite Achievements"
+                // no data for GameA
+            };
+            var agg = new GsAchievementAggregator(successStory, playniteAch);
+
+            var (achievements, source) = agg.GetAchievementsWithSource(GameA);
+            Assert.Equal("SuccessStory", source);
+            Assert.Equal(5, achievements.Count);
+        }
+
+        [Fact]
+        public void ResolutionOrder_PreservesPriority_WhenBothPluginsLive() {
+            // Normal case: both plugins installed and loaded -> priority order preserved,
+            // SuccessStory (priority 1) wins. No regression from the stale-data fix.
+            var successStory = new StubAchievementProvider {
+                IsInstalled = true,
+                IsPluginLoaded = true,
+                ProviderName = "SuccessStory",
+                Data = { [GameA] = MakeAchievements(2, 10) }
+            };
+            var playniteAch = new StubAchievementProvider {
+                IsInstalled = true,
+                IsPluginLoaded = true,
+                ProviderName = "Playnite Achievements",
+                Data = { [GameA] = MakeAchievements(9, 10) }
+            };
+            var agg = new GsAchievementAggregator(successStory, playniteAch);
+
+            var (_, source) = agg.GetAchievementsWithSource(GameA);
+            Assert.Equal("SuccessStory", source);
         }
 
         [Fact]

--- a/GsPlugin.Tests/GsApiClientHttpTests.cs
+++ b/GsPlugin.Tests/GsApiClientHttpTests.cs
@@ -344,6 +344,52 @@ namespace GsPlugin.Tests {
             }
         }
 
+        [Fact]
+        public async Task RequestDeleteMyData_Forbidden_ReturnsAlreadyOptedOut() {
+            var tempDir = CreateTempDir();
+            try {
+                InitDataManager(tempDir, "valid-token");
+
+                var handler = new MockHttpHandler {
+                    StatusCode = HttpStatusCode.Forbidden
+                };
+                var client = new GsApiClient(new HttpClient(handler));
+
+                var result = await client.RequestDeleteMyData(new DeleteDataReq());
+
+                Assert.NotNull(result);
+                Assert.False(result.success);
+                Assert.True(result.alreadyOptedOut);
+                Assert.False(result.authFailed);
+            }
+            finally {
+                Directory.Delete(tempDir, true);
+            }
+        }
+
+        [Fact]
+        public async Task RequestDeleteMyData_Unauthorized_ReturnsAuthFailed() {
+            var tempDir = CreateTempDir();
+            try {
+                InitDataManager(tempDir, "valid-token");
+
+                var handler = new MockHttpHandler {
+                    StatusCode = HttpStatusCode.Unauthorized
+                };
+                var client = new GsApiClient(new HttpClient(handler));
+
+                var result = await client.RequestDeleteMyData(new DeleteDataReq());
+
+                Assert.NotNull(result);
+                Assert.False(result.success);
+                Assert.True(result.authFailed);
+                Assert.False(result.alreadyOptedOut);
+            }
+            finally {
+                Directory.Delete(tempDir, true);
+            }
+        }
+
         // --- UnlinkAccount Tests ---
 
         [Fact]

--- a/GsPlugin.Tests/GsSyncHashIndexTests.cs
+++ b/GsPlugin.Tests/GsSyncHashIndexTests.cs
@@ -606,6 +606,7 @@ namespace GsPlugin.Tests {
 
         private sealed class StubAchievementProvider : IAchievementProvider {
             public bool IsInstalled => false;
+            public bool IsPluginLoaded => false;
             public string ProviderName => "stub";
             public string GetVersion() => "0";
             public (int unlocked, int total)? GetCounts(Guid gameId) => null;

--- a/GsPlugin.cs
+++ b/GsPlugin.cs
@@ -486,6 +486,15 @@ namespace GsPlugin {
         }
 
         /// <summary>
+        /// Registers an install token on demand from a user-initiated action (e.g. the
+        /// "Delete My Data" button). Startup token registration can fail on a transient
+        /// network error and does not retry until the next Playnite restart, which would
+        /// otherwise leave a token-authenticated action failing for the whole session.
+        /// Reuses the same gated registration + rotation-recovery logic as startup.
+        /// </summary>
+        internal Task EnsureInstallTokenReadyAsync() => EnsureInstallTokenAsync();
+
+        /// <summary>
         /// Ensures the install has a valid server-issued auth token stored in GsData.
         /// Starts in parallel with other startup work and is awaited before the first v4 sync.
         ///

--- a/GsPlugin.cs
+++ b/GsPlugin.cs
@@ -66,6 +66,12 @@ namespace GsPlugin {
         /// </summary>
         private readonly object _timerLock = new object();
         /// <summary>
+        /// Serializes the install-token registration flow so startup (EnsureInstallTokenAsync)
+        /// and on-demand callers (EnsureInstallTokenReadyAsync, e.g. the "Delete My Data"
+        /// button) cannot register concurrently and double-register the install.
+        /// </summary>
+        private readonly SemaphoreSlim _installTokenGate = new SemaphoreSlim(1, 1);
+        /// <summary>
         /// Unique identifier for the plugin itself.
         /// </summary>
         public override Guid Id { get; } = Guid.Parse("32975fed-6915-4dd3-a230-030cdc5265ae");
@@ -497,6 +503,30 @@ namespace GsPlugin {
                 return;
             }
 
+            // Serialize the entire registration + conflict-recovery sequence. Startup and
+            // on-demand callers can otherwise enter concurrently with an empty token and both
+            // register, producing a 409 and a RotateInstallId() that races the in-flight
+            // registration. The gate is held across registration, token storage, rotation, and retry.
+            await _installTokenGate.WaitAsync();
+            try {
+                // Re-check under the gate: a concurrent caller may have stored a token while we
+                // waited, making our registration redundant.
+                if (!string.IsNullOrEmpty(GsDataManager.Data.InstallToken)) {
+                    return;
+                }
+                await EnsureInstallTokenCoreAsync();
+            }
+            finally {
+                _installTokenGate.Release();
+            }
+        }
+
+        /// <summary>
+        /// Performs the actual token registration and 409 rotation-recovery. Always invoked
+        /// under <see cref="_installTokenGate"/> by <see cref="EnsureInstallTokenAsync"/>, so
+        /// concurrent startup and on-demand callers run one at a time.
+        /// </summary>
+        private async Task EnsureInstallTokenCoreAsync() {
             var installId = GsDataManager.Data.InstallID;
             if (string.IsNullOrEmpty(installId)) {
                 _logger.Warn("EnsureInstallTokenAsync: no InstallID available, skipping registration");
@@ -660,6 +690,13 @@ namespace GsPlugin {
                 }
                 catch (Exception ex) {
                     _logger.Error(ex, "Error closing Sentry");
+                }
+
+                try {
+                    _installTokenGate.Dispose();
+                }
+                catch (Exception ex) {
+                    _logger.Error(ex, "Error disposing install-token gate");
                 }
 
                 _apiClient = null;

--- a/Localization/de_DE.xaml
+++ b/Localization/de_DE.xaml
@@ -156,6 +156,7 @@ Sie müssen Playnite neu starten, damit alle Funktionen fortgesetzt werden.</sys
     <sys:String x:Key="LOCGsPluginErrorRetryFormat">Fehler: {0} Klicken Sie auf „Konto verknüpfen", um es erneut zu versuchen.</sys:String>
     <sys:String x:Key="LOCGsPluginErrorFormat">Fehler: {0}</sys:String>
     <sys:String x:Key="LOCGsPluginUnknownLinkingError">Unbekannter Fehler bei der Verknüpfung</sys:String>
+    <sys:String x:Key="LOCGsPluginInvalidUserIdFormat">Ungültiges Benutzer-ID-Format vom Server erhalten</sys:String>
     <sys:String x:Key="LOCGsPluginLinkingErrorFormat">Fehler bei der Verknüpfung: {0}</sys:String>
     <sys:String x:Key="LOCGsPluginNetworkError">Netzwerkfehler — Server nicht erreichbar. Bitte versuchen Sie es erneut.</sys:String>
     <sys:String x:Key="LOCGsPluginUnlinkFailed">Konto konnte nicht getrennt werden.</sys:String>

--- a/Localization/de_DE.xaml
+++ b/Localization/de_DE.xaml
@@ -169,6 +169,9 @@ Möchten Sie ein anderes Konto verknüpfen?</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteSuccess">Ihre Daten wurden gelöscht. Das Plugin ist jetzt deaktiviert.</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteRateLimited">Zu viele Löschanfragen. Bitte warten Sie 15 Minuten und versuchen Sie es erneut.</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteFailed">Datenlöschung fehlgeschlagen. Bitte versuchen Sie es später erneut.</sys:String>
+    <sys:String x:Key="LOCGsPluginDeleteNoToken">GameScrobbler konnte nicht erreicht werden, um die Löschung zu autorisieren. Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut.</sys:String>
+    <sys:String x:Key="LOCGsPluginDeleteAlreadyDone">Ihre Daten wurden bereits gelöscht. Das Plugin ist jetzt deaktiviert.</sys:String>
+    <sys:String x:Key="LOCGsPluginDeleteAuthFailed">Diese Installation konnte nicht verifiziert werden. Verknüpfen Sie Ihr Konto erneut und versuchen Sie dann erneut zu löschen.</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteError">Ein Fehler ist aufgetreten. Bitte versuchen Sie es später erneut.</sys:String>
     <sys:String x:Key="LOCGsPluginOptBackInSuccess">Plugin wieder aktiviert. Bitte starten Sie Playnite neu, um die Synchronisierung fortzusetzen.</sys:String>
 

--- a/Localization/en_US.xaml
+++ b/Localization/en_US.xaml
@@ -156,6 +156,7 @@ You will need to restart Playnite for all features to resume.</sys:String>
     <sys:String x:Key="LOCGsPluginErrorRetryFormat">Error: {0} Click "Link Account" to retry.</sys:String>
     <sys:String x:Key="LOCGsPluginErrorFormat">Error: {0}</sys:String>
     <sys:String x:Key="LOCGsPluginUnknownLinkingError">Unknown error occurred during linking</sys:String>
+    <sys:String x:Key="LOCGsPluginInvalidUserIdFormat">Invalid user ID format received from server</sys:String>
     <sys:String x:Key="LOCGsPluginLinkingErrorFormat">Error during linking: {0}</sys:String>
     <sys:String x:Key="LOCGsPluginNetworkError">Network error — could not reach the server. Please try again.</sys:String>
     <sys:String x:Key="LOCGsPluginUnlinkFailed">Failed to disconnect account.</sys:String>

--- a/Localization/en_US.xaml
+++ b/Localization/en_US.xaml
@@ -169,6 +169,9 @@ Do you want to link to a different account?</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteSuccess">Your data has been deleted. The plugin is now disabled.</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteRateLimited">Too many deletion requests. Please wait 15 minutes and try again.</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteFailed">Failed to request data deletion. Please try again later.</sys:String>
+    <sys:String x:Key="LOCGsPluginDeleteNoToken">Couldn't reach GameScrobbler to authorize the deletion. Check your internet connection and try again.</sys:String>
+    <sys:String x:Key="LOCGsPluginDeleteAlreadyDone">Your data has already been deleted. The plugin is now disabled.</sys:String>
+    <sys:String x:Key="LOCGsPluginDeleteAuthFailed">This installation couldn't be verified. Reconnect your account, then try deleting again.</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteError">An error occurred. Please try again later.</sys:String>
     <sys:String x:Key="LOCGsPluginOptBackInSuccess">Plugin re-enabled. Please restart Playnite to resume syncing.</sys:String>
 

--- a/Localization/fr_FR.xaml
+++ b/Localization/fr_FR.xaml
@@ -156,6 +156,7 @@ Vous devrez redémarrer Playnite pour que toutes les fonctionnalités reprennent
     <sys:String x:Key="LOCGsPluginErrorRetryFormat">Erreur : {0} Cliquez sur « Associer le compte » pour réessayer.</sys:String>
     <sys:String x:Key="LOCGsPluginErrorFormat">Erreur : {0}</sys:String>
     <sys:String x:Key="LOCGsPluginUnknownLinkingError">Erreur inconnue lors de l'association</sys:String>
+    <sys:String x:Key="LOCGsPluginInvalidUserIdFormat">Format d'identifiant utilisateur invalide reçu du serveur</sys:String>
     <sys:String x:Key="LOCGsPluginLinkingErrorFormat">Erreur lors de l'association : {0}</sys:String>
     <sys:String x:Key="LOCGsPluginNetworkError">Erreur réseau — impossible de contacter le serveur. Veuillez réessayer.</sys:String>
     <sys:String x:Key="LOCGsPluginUnlinkFailed">Échec de la dissociation du compte.</sys:String>

--- a/Localization/fr_FR.xaml
+++ b/Localization/fr_FR.xaml
@@ -169,6 +169,9 @@ Voulez-vous associer un autre compte ?</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteSuccess">Vos données ont été supprimées. Le plugin est maintenant désactivé.</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteRateLimited">Trop de demandes de suppression. Veuillez patienter 15 minutes et réessayer.</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteFailed">Échec de la demande de suppression. Veuillez réessayer plus tard.</sys:String>
+    <sys:String x:Key="LOCGsPluginDeleteNoToken">Impossible de joindre GameScrobbler pour autoriser la suppression. Vérifiez votre connexion Internet et réessayez.</sys:String>
+    <sys:String x:Key="LOCGsPluginDeleteAlreadyDone">Vos données ont déjà été supprimées. Le plugin est maintenant désactivé.</sys:String>
+    <sys:String x:Key="LOCGsPluginDeleteAuthFailed">Cette installation n'a pas pu être vérifiée. Reconnectez votre compte, puis réessayez de supprimer.</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteError">Une erreur est survenue. Veuillez réessayer plus tard.</sys:String>
     <sys:String x:Key="LOCGsPluginOptBackInSuccess">Plugin réactivé. Veuillez redémarrer Playnite pour reprendre la synchronisation.</sys:String>
 

--- a/Localization/hi_IN.xaml
+++ b/Localization/hi_IN.xaml
@@ -169,6 +169,9 @@
     <sys:String x:Key="LOCGsPluginDeleteSuccess">आपका डेटा हटा दिया गया है। प्लगइन अब अक्षम है।</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteRateLimited">बहुत अधिक हटाने के अनुरोध। कृपया 15 मिनट प्रतीक्षा करें और पुनः प्रयास करें।</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteFailed">डेटा हटाने का अनुरोध विफल। कृपया बाद में पुनः प्रयास करें।</sys:String>
+    <sys:String x:Key="LOCGsPluginDeleteNoToken">हटाने को अधिकृत करने के लिए GameScrobbler से संपर्क नहीं हो सका। कृपया अपना इंटरनेट कनेक्शन जांचें और पुनः प्रयास करें।</sys:String>
+    <sys:String x:Key="LOCGsPluginDeleteAlreadyDone">आपका डेटा पहले ही हटा दिया गया है। प्लगइन अब अक्षम है।</sys:String>
+    <sys:String x:Key="LOCGsPluginDeleteAuthFailed">इस इंस्टॉलेशन को सत्यापित नहीं किया जा सका। अपना खाता पुनः कनेक्ट करें, फिर हटाने का पुनः प्रयास करें।</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteError">एक त्रुटि हुई। कृपया बाद में पुनः प्रयास करें।</sys:String>
     <sys:String x:Key="LOCGsPluginOptBackInSuccess">प्लगइन फिर से सक्षम। सिंक फिर से शुरू करने के लिए Playnite रीस्टार्ट करें।</sys:String>
 

--- a/Localization/hi_IN.xaml
+++ b/Localization/hi_IN.xaml
@@ -156,6 +156,7 @@
     <sys:String x:Key="LOCGsPluginErrorRetryFormat">त्रुटि: {0} पुनः प्रयास के लिए "खाता लिंक करें" पर क्लिक करें।</sys:String>
     <sys:String x:Key="LOCGsPluginErrorFormat">त्रुटि: {0}</sys:String>
     <sys:String x:Key="LOCGsPluginUnknownLinkingError">लिंकिंग के दौरान अज्ञात त्रुटि हुई</sys:String>
+    <sys:String x:Key="LOCGsPluginInvalidUserIdFormat">सर्वर से अमान्य उपयोगकर्ता आईडी प्रारूप प्राप्त हुआ</sys:String>
     <sys:String x:Key="LOCGsPluginLinkingErrorFormat">लिंकिंग त्रुटि: {0}</sys:String>
     <sys:String x:Key="LOCGsPluginNetworkError">नेटवर्क त्रुटि — सर्वर से संपर्क नहीं हो सका। कृपया पुनः प्रयास करें।</sys:String>
     <sys:String x:Key="LOCGsPluginUnlinkFailed">खाता अनलिंक करने में विफल।</sys:String>

--- a/Localization/pt_BR.xaml
+++ b/Localization/pt_BR.xaml
@@ -156,6 +156,7 @@ Será necessário reiniciar o Playnite para retomar todas as funcionalidades.</s
     <sys:String x:Key="LOCGsPluginErrorRetryFormat">Erro: {0} Clique em "Vincular Conta" para tentar novamente.</sys:String>
     <sys:String x:Key="LOCGsPluginErrorFormat">Erro: {0}</sys:String>
     <sys:String x:Key="LOCGsPluginUnknownLinkingError">Ocorreu um erro desconhecido durante a vinculação</sys:String>
+    <sys:String x:Key="LOCGsPluginInvalidUserIdFormat">Formato de ID de usuário inválido recebido do servidor</sys:String>
     <sys:String x:Key="LOCGsPluginLinkingErrorFormat">Erro durante a vinculação: {0}</sys:String>
     <sys:String x:Key="LOCGsPluginNetworkError">Erro de rede — não foi possível conectar ao servidor. Tente novamente.</sys:String>
     <sys:String x:Key="LOCGsPluginUnlinkFailed">Falha ao desvincular conta.</sys:String>

--- a/Localization/pt_BR.xaml
+++ b/Localization/pt_BR.xaml
@@ -169,6 +169,9 @@ Deseja vincular a uma conta diferente?</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteSuccess">Seus dados foram excluídos. O plugin está desativado.</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteRateLimited">Muitas solicitações de exclusão. Aguarde 15 minutos e tente novamente.</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteFailed">Falha ao solicitar exclusão de dados. Tente novamente mais tarde.</sys:String>
+    <sys:String x:Key="LOCGsPluginDeleteNoToken">Não foi possível conectar ao GameScrobbler para autorizar a exclusão. Verifique sua conexão com a internet e tente novamente.</sys:String>
+    <sys:String x:Key="LOCGsPluginDeleteAlreadyDone">Seus dados já foram excluídos. O plugin agora está desativado.</sys:String>
+    <sys:String x:Key="LOCGsPluginDeleteAuthFailed">Não foi possível verificar esta instalação. Reconecte sua conta e tente excluir novamente.</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteError">Ocorreu um erro. Tente novamente mais tarde.</sys:String>
     <sys:String x:Key="LOCGsPluginOptBackInSuccess">Plugin reativado. Reinicie o Playnite para retomar a sincronização.</sys:String>
 

--- a/Localization/ru_RU.xaml
+++ b/Localization/ru_RU.xaml
@@ -156,6 +156,7 @@ ID пользователя: {0}</sys:String>
     <sys:String x:Key="LOCGsPluginErrorRetryFormat">Ошибка: {0} Нажмите «Привязать учётную запись», чтобы повторить.</sys:String>
     <sys:String x:Key="LOCGsPluginErrorFormat">Ошибка: {0}</sys:String>
     <sys:String x:Key="LOCGsPluginUnknownLinkingError">Произошла неизвестная ошибка при привязке</sys:String>
+    <sys:String x:Key="LOCGsPluginInvalidUserIdFormat">От сервера получен неверный формат идентификатора пользователя</sys:String>
     <sys:String x:Key="LOCGsPluginLinkingErrorFormat">Ошибка при привязке: {0}</sys:String>
     <sys:String x:Key="LOCGsPluginNetworkError">Сетевая ошибка — не удалось связаться с сервером. Попробуйте ещё раз.</sys:String>
     <sys:String x:Key="LOCGsPluginUnlinkFailed">Не удалось отвязать учётную запись.</sys:String>

--- a/Localization/ru_RU.xaml
+++ b/Localization/ru_RU.xaml
@@ -169,6 +169,9 @@ ID пользователя: {0}</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteSuccess">Ваши данные удалены. Плагин отключён.</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteRateLimited">Слишком много запросов на удаление. Подождите 15 минут и попробуйте снова.</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteFailed">Не удалось запросить удаление данных. Попробуйте позже.</sys:String>
+    <sys:String x:Key="LOCGsPluginDeleteNoToken">Не удалось связаться с GameScrobbler для подтверждения удаления. Проверьте подключение к интернету и повторите попытку.</sys:String>
+    <sys:String x:Key="LOCGsPluginDeleteAlreadyDone">Ваши данные уже удалены. Плагин теперь отключён.</sys:String>
+    <sys:String x:Key="LOCGsPluginDeleteAuthFailed">Не удалось подтвердить эту установку. Привяжите учётную запись заново и повторите удаление.</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteError">Произошла ошибка. Попробуйте позже.</sys:String>
     <sys:String x:Key="LOCGsPluginOptBackInSuccess">Плагин включён заново. Перезапустите Playnite для возобновления синхронизации.</sys:String>
 

--- a/Localization/zh_CN.xaml
+++ b/Localization/zh_CN.xaml
@@ -169,6 +169,9 @@
     <sys:String x:Key="LOCGsPluginDeleteSuccess">您的数据已删除。插件已禁用。</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteRateLimited">删除请求过于频繁。请等待 15 分钟后重试。</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteFailed">数据删除请求失败。请稍后重试。</sys:String>
+    <sys:String x:Key="LOCGsPluginDeleteNoToken">无法连接到 GameScrobbler 以授权删除操作。请检查您的网络连接后重试。</sys:String>
+    <sys:String x:Key="LOCGsPluginDeleteAlreadyDone">您的数据已被删除。插件现已禁用。</sys:String>
+    <sys:String x:Key="LOCGsPluginDeleteAuthFailed">无法验证此安装。请重新关联您的账户后再尝试删除。</sys:String>
     <sys:String x:Key="LOCGsPluginDeleteError">发生错误。请稍后重试。</sys:String>
     <sys:String x:Key="LOCGsPluginOptBackInSuccess">插件已重新启用。请重启 Playnite 以恢复同步。</sys:String>
 

--- a/Localization/zh_CN.xaml
+++ b/Localization/zh_CN.xaml
@@ -156,6 +156,7 @@
     <sys:String x:Key="LOCGsPluginErrorRetryFormat">错误：{0} 点击"关联账户"重试。</sys:String>
     <sys:String x:Key="LOCGsPluginErrorFormat">错误：{0}</sys:String>
     <sys:String x:Key="LOCGsPluginUnknownLinkingError">关联过程中发生未知错误</sys:String>
+    <sys:String x:Key="LOCGsPluginInvalidUserIdFormat">从服务器收到的用户 ID 格式无效</sys:String>
     <sys:String x:Key="LOCGsPluginLinkingErrorFormat">关联错误：{0}</sys:String>
     <sys:String x:Key="LOCGsPluginNetworkError">网络错误——无法连接到服务器。请重试。</sys:String>
     <sys:String x:Key="LOCGsPluginUnlinkFailed">解除关联失败。</sys:String>

--- a/Services/GsAccountLinkingService.cs
+++ b/Services/GsAccountLinkingService.cs
@@ -100,7 +100,7 @@ namespace GsPlugin.Services {
                 return LinkingResult.CreateError("Please enter a valid token", context);
             }
 
-            GsLogger.Info($"Starting {context} account linking.");
+            GsLogger.Info($"Starting {context} account linking (install_id={GsDataManager.Data.InstallID}).");
             GsSentry.AddBreadcrumb(
                 message: $"Starting {context} account linking",
                 category: "linking",
@@ -122,21 +122,39 @@ namespace GsPlugin.Services {
                 }
 
                 if (response.success) {
-                    if (response.userId != GsData.NotLinkedValue
-                        && (string.IsNullOrWhiteSpace(response.userId) || response.userId.Length > 256)) {
+                    // A verify can succeed yet resolve to the "not_linked" sentinel (or an empty
+                    // user id): the token was accepted but the server did NOT bind this install to
+                    // an account. Reporting that as success made the settings UI show
+                    // "Successfully linked!" while the connection status stayed "Disconnected" and
+                    // the website's linking page kept polling "not linked" (issue #54). Treat it as
+                    // a failed link, clear any local link so state matches the server, and route the
+                    // user to fetch a fresh token (same recovery path as an expired token).
+                    if (!IsLinkedUserId(response.userId)) {
+                        GsDataManager.MutateAndSave(d => d.LinkedUserId = null);
+                        OnLinkingStatusChanged();
+
+                        GsLogger.Error($"{context} linking did not complete: token verified but the server returned a not-linked result (install_id={GsDataManager.Data.InstallID}, userId={response.userId ?? "null"}).");
+                        GsSentry.CaptureMessage(
+                            $"{context} linking verified but returned not-linked (install_id={GsDataManager.Data.InstallID})",
+                            SentryLevel.Warning);
+
+                        string notLinkedMessage = GsLocalization.Get(
+                            "LOCGsPluginStatusTokenExpired",
+                            "Token expired — click \"Open website to link\" to get a new one.");
+                        return LinkingResult.CreateError(notLinkedMessage, context, isTokenExpiry: true);
+                    }
+
+                    if (response.userId.Length > 256) {
                         string errorMessage = "Invalid user ID format received from server";
                         GsLogger.Error($"{context} linking failed: {errorMessage}");
                         return LinkingResult.CreateError(errorMessage, context);
                     }
-                    GsDataManager.MutateAndSave(d => {
-                        d.LinkedUserId = response.userId == GsData.NotLinkedValue
-                            ? null
-                            : response.userId;
-                    });
+
+                    GsDataManager.MutateAndSave(d => d.LinkedUserId = response.userId);
                     // Notify listeners of status change
                     OnLinkingStatusChanged();
 
-                    GsLogger.Info($"Account successfully linked via {context} to User ID: {response.userId}");
+                    GsLogger.Info($"Account successfully linked via {context} to User ID: {response.userId} (install_id={GsDataManager.Data.InstallID})");
                     GsSentry.AddBreadcrumb(
                         message: $"{context} account linking successful",
                         category: "linking",
@@ -203,6 +221,16 @@ namespace GsPlugin.Services {
             // Allow alphanumeric, hyphens, underscores, dots, plus, equals, slashes (covers JWT/base64 tokens)
             if (!Regex.IsMatch(token, @"^[a-zA-Z0-9\-_\.+=\/]+$")) return false;
             return true;
+        }
+
+        /// <summary>
+        /// Returns true when a verify response's user id represents a real linked account.
+        /// A successful verify that resolves to the <see cref="GsData.NotLinkedValue"/> sentinel
+        /// (or an empty value) means the token was accepted without actually binding the install
+        /// to an account, so callers must not treat it as a successful link (issue #54).
+        /// </summary>
+        internal static bool IsLinkedUserId(string userId) {
+            return !string.IsNullOrWhiteSpace(userId) && userId != GsData.NotLinkedValue;
         }
 
         /// <summary>

--- a/Services/GsAccountLinkingService.cs
+++ b/Services/GsAccountLinkingService.cs
@@ -145,7 +145,9 @@ namespace GsPlugin.Services {
                     }
 
                     if (response.userId.Length > 256) {
-                        string errorMessage = "Invalid user ID format received from server";
+                        string errorMessage = GsLocalization.Get(
+                            "LOCGsPluginInvalidUserIdFormat",
+                            "Invalid user ID format received from server");
                         GsLogger.Error($"{context} linking failed: {errorMessage}");
                         return LinkingResult.CreateError(errorMessage, context);
                     }

--- a/Services/GsAchievementAggregator.cs
+++ b/Services/GsAchievementAggregator.cs
@@ -18,7 +18,22 @@ namespace GsPlugin.Services {
 
         public bool IsInstalled => _providers.Any(p => p.IsInstalled);
 
+        public bool IsPluginLoaded => _providers.Any(p => p.IsPluginLoaded);
+
         public string GetVersion() => null;
+
+        /// <summary>
+        /// Installed providers in resolution order: live plugins first (their data is
+        /// kept fresh), then data-only providers whose plugin is no longer loaded but
+        /// whose data directory still lingers on disk (possibly stale). Priority order
+        /// is preserved within each group. This prevents a leftover SuccessStory data
+        /// folder from shadowing an actually-installed provider such as Playnite
+        /// Achievements.
+        /// </summary>
+        private IEnumerable<IAchievementProvider> ResolutionOrder() {
+            return _providers.Where(p => p.IsInstalled && p.IsPluginLoaded)
+                .Concat(_providers.Where(p => p.IsInstalled && !p.IsPluginLoaded));
+        }
 
         /// <summary>
         /// Returns both counts atomically from the first provider that has data,
@@ -26,8 +41,7 @@ namespace GsPlugin.Services {
         /// that return an empty game-achievements object don't block fallback.
         /// </summary>
         public (int unlocked, int total)? GetCounts(Guid gameId) {
-            foreach (var p in _providers) {
-                if (!p.IsInstalled) continue;
+            foreach (var p in ResolutionOrder()) {
                 var counts = p.GetCounts(gameId);
                 if (counts.HasValue && counts.Value.total > 0) return counts;
             }
@@ -35,8 +49,7 @@ namespace GsPlugin.Services {
         }
 
         public List<AchievementItem> GetAchievements(Guid gameId) {
-            foreach (var p in _providers) {
-                if (!p.IsInstalled) continue;
+            foreach (var p in ResolutionOrder()) {
                 var achievements = p.GetAchievements(gameId);
                 if (achievements != null) return achievements;
             }
@@ -48,8 +61,7 @@ namespace GsPlugin.Services {
         /// Used for diagnostic logging.
         /// </summary>
         public (List<AchievementItem> achievements, string providerName) GetAchievementsWithSource(Guid gameId) {
-            foreach (var p in _providers) {
-                if (!p.IsInstalled) continue;
+            foreach (var p in ResolutionOrder()) {
                 var achievements = p.GetAchievements(gameId);
                 if (achievements != null) return (achievements, p.ProviderName);
             }

--- a/Services/GsPlayniteAchievementsHelper.cs
+++ b/Services/GsPlayniteAchievementsHelper.cs
@@ -37,9 +37,12 @@ namespace GsPlugin.Services {
         public bool IsInstalled {
             get {
                 if (File.Exists(_dbPath)) return true;
-                return _api?.Addons?.Plugins?.Any(p => p.Id == PlayniteAchievementsId) == true;
+                return IsPluginLoaded;
             }
         }
+
+        public bool IsPluginLoaded =>
+            _api?.Addons?.Plugins?.Any(p => p.Id == PlayniteAchievementsId) == true;
 
         public (int unlocked, int total)? GetCounts(Guid gameId) {
             try {

--- a/Services/GsScrobblingService.cs
+++ b/Services/GsScrobblingService.cs
@@ -1000,7 +1000,19 @@ namespace GsPlugin.Services {
                 if (_achievementHelper is GsAchievementAggregator agg) {
                     var installed = agg.GetInstalledProviders();
                     _logger.Info($"Achievement providers installed: {installed.Count} — " +
-                        string.Join(", ", installed.Select(p => $"{p.ProviderName} (v{p.GetVersion() ?? "?"})")));
+                        string.Join(", ", installed.Select(p =>
+                            $"{p.ProviderName} (v{p.GetVersion() ?? "?"}, " +
+                            $"{(p.IsPluginLoaded ? "plugin loaded" : "data-only")})")));
+
+                    // A data-only provider (data directory present but plugin not loaded)
+                    // means the addon was uninstalled/disabled while its cache lingered.
+                    // The aggregator now deprioritizes it, but flag it so stale-data reports
+                    // are diagnosable from the log alone. See issue #66.
+                    var stale = installed.Where(p => !p.IsPluginLoaded).ToList();
+                    if (stale.Count > 0) {
+                        _logger.Warn("Achievement diag: data-only provider(s) with no loaded plugin — " +
+                            $"data may be stale: {string.Join(", ", stale.Select(p => p.ProviderName))}");
+                    }
                 }
                 _logger.Info($"Achievement diff: {allGames.Count} total games, " +
                     $"index has {achievementFingerprints.Count} entries");

--- a/Services/GsSuccessStoryHelper.cs
+++ b/Services/GsSuccessStoryHelper.cs
@@ -37,9 +37,12 @@ namespace GsPlugin.Services {
         public bool IsInstalled {
             get {
                 if (_dataPath != null && Directory.Exists(_dataPath)) return true;
-                return _api?.Addons?.Plugins?.Any(p => p.Id == SuccessStoryId) == true;
+                return IsPluginLoaded;
             }
         }
+
+        public bool IsPluginLoaded =>
+            _api?.Addons?.Plugins?.Any(p => p.Id == SuccessStoryId) == true;
 
         public (int unlocked, int total)? GetCounts(Guid gameId) {
             var achievements = GetAchievements(gameId);

--- a/Services/IAchievementProvider.cs
+++ b/Services/IAchievementProvider.cs
@@ -44,6 +44,16 @@ namespace GsPlugin.Services {
     /// </summary>
     public interface IAchievementProvider {
         bool IsInstalled { get; }
+
+        /// <summary>
+        /// True when the provider's actual Playnite plugin is currently loaded
+        /// (present in <c>Addons.Plugins</c>), as opposed to only having a lingering
+        /// data directory on disk after the plugin was uninstalled or disabled.
+        /// Data reads work off-disk either way, but a live plugin keeps its data fresh,
+        /// so the aggregator prefers live providers to avoid serving stale achievements.
+        /// </summary>
+        bool IsPluginLoaded { get; }
+
         string ProviderName { get; }
         string GetVersion();
 

--- a/View/GsPluginSettingsViewModel.cs
+++ b/View/GsPluginSettingsViewModel.cs
@@ -388,6 +388,20 @@ namespace GsPlugin.Models {
                 Settings.IsDeleting = true;
                 Settings.DeleteStatusMessage = GsLocalization.Get("LOCGsPluginDeletingRequesting", "Requesting data deletion...");
 
+                // Deletion is strictly token-authenticated. If startup registration failed
+                // (e.g. transient network error), the local token stays empty for the whole
+                // session and every delete attempt would fail before reaching the server —
+                // the "it keeps failing" symptom. Register a token on demand first.
+                if (string.IsNullOrEmpty(GsDataManager.DataOrNull?.InstallToken)) {
+                    await _plugin.EnsureInstallTokenReadyAsync();
+                }
+
+                if (string.IsNullOrEmpty(GsDataManager.DataOrNull?.InstallToken)) {
+                    Settings.DeleteStatusMessage = GsLocalization.Get("LOCGsPluginDeleteNoToken",
+                        "Couldn't reach GameScrobbler to authorize the deletion. Check your internet connection and try again.");
+                    return;
+                }
+
                 var result = await _apiClient.RequestDeleteMyData(new DeleteDataReq());
 
                 if (result != null && result.success) {
@@ -399,8 +413,22 @@ namespace GsPlugin.Models {
                     // Notify UI to refresh connection status and button visibility
                     OnLinkingStatusChanged();
                 }
+                else if (result != null && result.alreadyOptedOut) {
+                    // Server says this install is already opted out — the data is gone.
+                    // Sync local state so the Delete button hides instead of looping on a
+                    // failure the user can never clear by retrying.
+                    GsDataManager.PerformOptOut();
+                    GsSyncHashIndex.ClearAll();
+                    Settings.DeleteStatusMessage = GsLocalization.Get("LOCGsPluginDeleteAlreadyDone",
+                        "Your data has already been deleted. The plugin is now disabled.");
+                    OnLinkingStatusChanged();
+                }
                 else if (result != null && result.rateLimited) {
                     Settings.DeleteStatusMessage = GsLocalization.Get("LOCGsPluginDeleteRateLimited", "Too many deletion requests. Please wait 15 minutes and try again.");
+                }
+                else if (result != null && result.authFailed) {
+                    Settings.DeleteStatusMessage = GsLocalization.Get("LOCGsPluginDeleteAuthFailed",
+                        "This installation couldn't be verified. Reconnect your account, then try deleting again.");
                 }
                 else {
                     Settings.DeleteStatusMessage = GsLocalization.Get("LOCGsPluginDeleteFailed", "Failed to request data deletion. Please try again later.");
@@ -430,7 +458,8 @@ namespace GsPlugin.Models {
                 if (result == null || !result.success) {
                     if (result?.rateLimited == true) {
                         Settings.DeleteStatusMessage = GsLocalization.Get("LOCGsPluginOptBackInRateLimited", "Too many attempts. Please wait and try again.");
-                    } else {
+                    }
+                    else {
                         Settings.DeleteStatusMessage = GsLocalization.Get("LOCGsPluginOptBackInFailed", "Failed to re-enable. Please restart Playnite to try again.");
                     }
                     return;


### PR DESCRIPTION
## Problem (issue #66)

Multiple users report achievements not syncing. The plugin-side logs actually show data being read and the diff sync queued successfully, so the failure is in **provider selection**, not data reading.

Since v2.4.0, a provider counts as "installed" whenever its data directory exists on disk, even after the addon is uninstalled or disabled. A leftover `SuccessStory/` folder (priority 1) then shadows a live provider such as Playnite Achievements, serving frozen or partial achievements that never refresh.

This matches the reports in the thread:
- **BloodShed-Oni**: log shows `SuccessStory (v?)` (plugin not loaded) winning as "first hit" ahead of live `Playnite Achievements v2.1.5`.
- **hecgzz**: used SuccessStory, stopped, now runs Playnite Achievements only, so the stale SuccessStory folder wins.

I also verified against the `v1.6.2` tag of Playnite Achievements that it uses the same `achievement_cache.db` schema our reader expects, so that older version is **not** a schema-mismatch problem.

## Fix

- Add `IAchievementProvider.IsPluginLoaded` to distinguish a live plugin (present in `Addons.Plugins`) from a lingering data directory on disk.
- `GsAchievementAggregator` now resolves installed providers **live-first**, using data-only folders only as a last resort when no live provider has data for a game. Priority order is preserved within each group, so the normal (both-installed) case is unchanged.
- Diagnostics label each provider `plugin loaded` vs `data-only` and warn when a stale data-only provider is present, so future reports are diagnosable from the log alone.

## Tests

- 3 new aggregator tests: stale-shadowing prevention, data-only fallback when no live provider has data, and no-regression when both plugins are live.
- Full suite: **317/317 passing**.

Fixes #66


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved data deletion handling with clearer outcomes for missing authorization, already-completed deletion, and installation verification failures.
  * Added automatic authorization preparation before requesting data deletion.
  * Achievement data now prioritizes currently active providers over stale data.
  * Account linking now rejects invalid or unlinked account responses and provides clearer recovery guidance.

* **Bug Fixes**
  * Improved handling of authorization and opt-out responses from the server.
  * Added clearer invalid user ID and reconnect guidance.

* **Localization**
  * Added corresponding status and error messages across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->