### PR TITLE
docs: add AGENTS.md with Cursor Cloud (Linux) setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# AGENTS.md
+
+General build, test, format, and architecture guidance for this repository lives in
+[`CLAUDE.md`](CLAUDE.md) and [`README.md`](README.md). Read those first — this file only
+adds notes specific to the Cursor Cloud (Linux) agent environment.
+
+## Cursor Cloud specific instructions
+
+Cursor Cloud agents run on **Linux**, but this project is a **Windows-only .NET Framework
+4.6.2 WPF Playnite plugin**. That platform mismatch is the single most important thing to
+understand before trying to build, test, or run anything here.
+
+### What the environment already has (installed in the VM snapshot)
+
+- **.NET SDK 8.0.x** (`dotnet`) — pinned by `global.json`; used for `dotnet restore` and the
+  SDK-style test project.
+- **Mono 6.8** — provides the .NET Framework runtime/reference framework list on Linux.
+- **`nuget`** — a wrapper at `/usr/local/bin/nuget` that runs `mono /opt/nuget/nuget.exe`;
+  needed to restore the `packages.config`-based main project (`dotnet restore` alone does
+  **not** restore `packages.config` projects).
+- **PowerShell 7 (`pwsh`) + Pester** — for the repo's PowerShell scripts and their tests.
+
+The startup update script only restores dependencies (`nuget restore` + `dotnet restore`).
+The toolchain above is baked into the snapshot, not reinstalled on every run.
+
+### What can and cannot run on Linux
+
+- **Cannot build the plugin (`GsPlugin.csproj`) on Linux.** It is an old-style WPF project;
+  markup compilation (`Microsoft.WinFX.targets` / `PresentationBuildTasks`) requires the
+  Windows-only `PresentationCore`/`PresentationFramework` assemblies. A build here fails with
+  `error MC6000`. This is expected — the authoritative build is Windows MSBuild (see
+  `CLAUDE.md` and `.github/workflows/build.yml`, which runs on `windows-2022`).
+- **Cannot run the xUnit suite (`GsPlugin.Tests`) on Linux.** The test project has a
+  `ProjectReference` to the WPF plugin, so it transitively hits the same WPF build wall.
+  Run it on Windows with `dotnet test ... --no-build` after an MSBuild build.
+- **`nuget restore GsPlugin.sln` and `dotnet restore GsPlugin.Tests/GsPlugin.Tests.csproj`
+  both succeed on Linux.**
+- **`dotnet format` does NOT truly verify formatting on Linux.** It exits 0 but only logs
+  "Required references did not load" because it cannot load the WPF project. The pre-commit
+  hook (`hooks/pre-commit`) already detects this and skips on non-Windows; the authoritative
+  formatting check runs on Windows (`scripts/format-code.ps1`). Do not treat a green
+  `dotnet format` on Linux as a real formatting pass.
+- **The PowerShell script tests DO run on Linux** and are the one runnable automated suite
+  here:
+  `pwsh -NoProfile -Command "Invoke-Pester -Path scripts/update-installer-manifest.Tests.ps1, scripts/generate-release-highlights.Tests.ps1 -Output Detailed"`
+- **Cannot run/pack the plugin on Linux.** Running it requires the Playnite desktop app +
+  WebView2 on Windows; packing uses the Windows `Toolbox.exe`.
+
+### Practical guidance for changes
+
+- For edits to plugin C# code (`Api/`, `Services/`, `Models/`, `Infrastructure/`, `View/`),
+  you can read/analyze and restore dependencies on Linux, but you cannot compile or run the
+  xUnit tests here — call out that build/test verification must happen on Windows.
+- For edits to the PowerShell tooling under `scripts/`, add/extend the Pester tests and run
+  them with `pwsh`/`Invoke-Pester` as shown above — that fully works on Linux.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the Cursor Cloud (Linux) development environment for this **Windows-only .NET Framework 4.6.2 WPF Playnite plugin**, and records durable, non-obvious caveats for future cloud agents.

The only code change is a new `AGENTS.md`. All tooling installs live in the VM snapshot; the startup update script only refreshes dependencies.

## Environment installed (VM snapshot)

- .NET SDK 8.0.423 (`dotnet`, pinned by `global.json`)
- Mono 6.8 (.NET Framework runtime/reference framework list)
- `nuget` wrapper at `/usr/local/bin/nuget` → `mono /opt/nuget/nuget.exe` (needed for `packages.config` restore)
- PowerShell 7.6 + Pester 6 (for the repo's PowerShell scripts/tests)

## Startup update script

```
nuget restore GsPlugin.sln
dotnet restore GsPlugin.Tests/GsPlugin.Tests.csproj
```

## What works vs. what is Windows-only on Linux

| Task | Linux (cloud) | Notes |
| --- | --- | --- |
| `nuget restore` + `dotnet restore` | ✅ Works | 37 `packages.config` packages + SDK test project |
| PowerShell Pester tests | ✅ 21/21 pass | `scripts/*.Tests.ps1` — the one runnable automated suite here |
| Build plugin (`GsPlugin.csproj`) | ❌ Windows-only | WPF markup compile fails with `error MC6000` (needs `PresentationCore`/`PresentationFramework`) |
| xUnit suite (`GsPlugin.Tests`) | ❌ Windows-only | `ProjectReference` to the WPF plugin hits the same wall |
| `dotnet format` (lint) | ⚠️ No real verification | Exits 0 but "references did not load"; authoritative check is Windows (matches `hooks/pre-commit`) |
| Run / pack plugin | ❌ Windows-only | Needs Playnite desktop + WebView2 / `Toolbox.exe` |

The authoritative build/test/pack pipeline is Windows MSBuild (see `.github/workflows/build.yml`, `windows-2022`).

## Verification

- `nuget restore` + `dotnet restore` succeed and are idempotent.
- `Invoke-Pester` on `scripts/update-installer-manifest.Tests.ps1` and `scripts/generate-release-highlights.Tests.ps1`: **21 passed, 0 failed**.
- Reproduced the `MC6000` WPF build blocker to confirm the plugin/xUnit path is Windows-only.

## Notes

- `AGENTS.md` references `CLAUDE.md`/`README.md` for standard commands rather than duplicating them.
- This PR intentionally does **not** touch the pre-existing CRLF/LF line-ending diffs present in the checkout.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5e0e2c5-f614-4a76-a36d-9da02aa105f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5e0e2c5-f614-4a76-a36d-9da02aa105f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

