### PR TITLE
fix(telemetry): bound PostHog client dispose during shutdown

### DIFF
--- a/Infrastructure/GsPostHog.cs
+++ b/Infrastructure/GsPostHog.cs
@@ -106,6 +106,12 @@ namespace GsPlugin.Infrastructure {
                 var disposeTask = Task.Run(() => client.Dispose());
                 if (!disposeTask.Wait(TimeSpan.FromSeconds(2))) {
                     _logger.Warn("PostHog dispose timed out during shutdown; abandoning");
+                    // Dispose keeps running in the background after we give up waiting on it —
+                    // observe any fault it eventually throws so it doesn't surface later as an
+                    // unobserved task exception.
+                    disposeTask.ContinueWith(t => {
+                        try { _logger.Warn(t.Exception?.GetBaseException(), "PostHog dispose failed after shutdown timeout (non-critical)"); } catch { }
+                    }, TaskContinuationOptions.OnlyOnFaulted);
                 }
             }
             catch (Exception ex) {

--- a/Infrastructure/GsPostHog.cs
+++ b/Infrastructure/GsPostHog.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using Playnite.SDK;
 using PostHog;
@@ -91,9 +92,21 @@ namespace GsPlugin.Infrastructure {
         /// Shuts down the PostHog client and releases resources.
         /// </summary>
         public static void Shutdown() {
+            var client = _client;
+            _client = null;
+            if (client == null) {
+                return;
+            }
+
             try {
-                _client?.Dispose();
-                _client = null;
+                // Bounded flush: PostHogClient.Dispose() blocks synchronously on an unbounded
+                // async flush (DisposeAsync().GetAwaiter().GetResult()), which can hang Playnite
+                // on exit when the ingest endpoint is slow/unreachable. Race it against a timeout
+                // instead of waiting on it directly.
+                var disposeTask = Task.Run(() => client.Dispose());
+                if (!disposeTask.Wait(TimeSpan.FromSeconds(2))) {
+                    _logger.Warn("PostHog dispose timed out during shutdown; abandoning");
+                }
             }
             catch (Exception ex) {
                 try { _logger.Debug(ex, "PostHog shutdown failed (non-critical)"); } catch { }


### PR DESCRIPTION
## Summary
- `GsPostHog.Shutdown()` called `PostHogClient.Dispose()`, which internally blocks synchronously (`DisposeAsync().AsTask().GetAwaiter().GetResult()`) with no timeout while flushing queued analytics events over HTTP.
- If the PostHog ingest endpoint is slow or unreachable, this hangs Playnite's shutdown path indefinitely (and blocks Windows shutdown as a result), since `GsPlugin.Dispose()` calls it directly during exit.
- `GsSentry.Shutdown()` already guards against this exact failure mode with a deliberate 2-second bounded flush; that same protection was missing for PostHog.
- Fix: run `client.Dispose()` on a background task and wait on it with a 2-second timeout, abandoning the dispose if it doesn't complete in time, matching the Sentry convention.

Fixes #84

## Test plan
- [x] `dotnet build GsPlugin.Tests/GsPlugin.Tests.csproj -c Release` — builds clean, 0 errors (also rebuilds `GsPlugin.csproj` via project reference)
- [x] `dotnet test GsPlugin.Tests/GsPlugin.Tests.csproj --configuration Release --no-build` — all 325 tests pass
- [ ] Manual verification in Playnite that exit no longer hangs when PostHog ingest is unreachable (reporter should confirm on next release)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application shutdown reliability by safely handling analytics client cleanup.
  * Prevented shutdown delays when cleanup takes too long, with a warning logged if necessary.
  * Ensured shutdown completes safely even when analytics services are unavailable or cleanup encounters an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->