### PR TITLE
fix(sync): confirm queue completion before committing sync baseline

### DIFF
--- a/Api/Dtos.cs
+++ b/Api/Dtos.cs
@@ -69,6 +69,23 @@ namespace GsPlugin.Api {
         public string lastSyncAt { get; set; }
     }
 
+    /// <summary>
+    /// Response from GET /api/playnite/queue/status/{queueId}. Polled after a
+    /// "queued" response so the client can wait for terminal worker state
+    /// (completed/failed) instead of treating queue admission as completion.
+    /// </summary>
+    public class QueueStatusRes {
+        public bool success { get; set; }
+        public QueueStatusData data { get; set; }
+    }
+
+    public class QueueStatusData {
+        public string id { get; set; }
+        /// <summary>pending | processing | completed | partial | failed | retrying</summary>
+        public string status { get; set; }
+        public string errorMessage { get; set; }
+    }
+
     public class ScrobbleFinishReq {
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string user_id { get; set; }

--- a/Api/GsApiClient.cs
+++ b/Api/GsApiClient.cs
@@ -591,6 +591,20 @@ namespace GsPlugin.Api {
             }
         }
 
+        /// <summary>
+        /// Polls the terminal status of a previously queued sync job. Unauthenticated on the
+        /// server (keyed by the opaque queueId returned at enqueue time) and intentionally
+        /// bypasses the shared circuit breaker — a poll loop can call this several times per
+        /// sync attempt, and transient failures here must not burn the failure budget shared
+        /// with core sync/scrobble calls.
+        /// </summary>
+        public async Task<QueueStatusRes> GetQueueStatus(string queueId) {
+            if (string.IsNullOrEmpty(queueId)) {
+                return null;
+            }
+            return await GetJsonAsync<QueueStatusRes>($"{_apiBaseUrl}/api/playnite/queue/status/{queueId}");
+        }
+
         #endregion
 
         #region Allowed Plugins

--- a/Api/IGsApiClient.cs
+++ b/Api/IGsApiClient.cs
@@ -29,5 +29,6 @@ namespace GsPlugin.Api {
         Task<RegisterInstallTokenRes> RegisterInstallToken(string installId);
         Task<string> GetDashboardToken();
         Task<PlayniteNotificationsRes> GetNotifications();
+        Task<QueueStatusRes> GetQueueStatus(string queueId);
     }
 }

--- a/GsPlugin.Tests/GsApiClientValidationTests.cs
+++ b/GsPlugin.Tests/GsApiClientValidationTests.cs
@@ -457,6 +457,12 @@ namespace GsPlugin.Tests {
         public Task<PlayniteNotificationsRes> GetNotifications() =>
             Task.FromResult(new PlayniteNotificationsRes());
 
+        public Task<QueueStatusRes> GetQueueStatus(string queueId) =>
+            Task.FromResult(new QueueStatusRes {
+                success = true,
+                data = new QueueStatusData { status = "completed" }
+            });
+
         public Task<UnlinkRes> UnlinkAccount() =>
             Task.FromResult(new UnlinkRes { success = true });
     }

--- a/GsPlugin.Tests/GsSyncHashIndexTests.cs
+++ b/GsPlugin.Tests/GsSyncHashIndexTests.cs
@@ -598,6 +598,11 @@ namespace GsPlugin.Tests {
             public Task<string> GetDashboardToken() => Task.FromResult("tok");
             public Task<PlayniteNotificationsRes> GetNotifications() =>
                 Task.FromResult(new PlayniteNotificationsRes());
+            public Task<QueueStatusRes> GetQueueStatus(string queueId) =>
+                Task.FromResult(new QueueStatusRes {
+                    success = true,
+                    data = new QueueStatusData { status = "completed" }
+                });
         }
 
         private static GsScrobblingService CreateService(IGsApiClient client) {

--- a/Services/GsScrobblingService.cs
+++ b/Services/GsScrobblingService.cs
@@ -567,6 +567,65 @@ namespace GsPlugin.Services {
                 syncId => _apiClient.SyncAchievementsFullAbort(syncId));
         }
 
+        /// <summary>Polling cadence for <see cref="TryConfirmQueueCompletionAsync"/>.</summary>
+        private static readonly TimeSpan QueueStatusPollInterval = TimeSpan.FromSeconds(1.5);
+
+        /// <summary>
+        /// Total time budget for <see cref="TryConfirmQueueCompletionAsync"/>. Matches the server's
+        /// documented "1-5 seconds" typical processing time with margin, so a poll never meaningfully
+        /// delays startup/library-updated callbacks that await these sync methods.
+        /// </summary>
+        private static readonly TimeSpan QueueStatusPollBudget = TimeSpan.FromSeconds(8);
+
+        /// <summary>
+        /// Best-effort check of a queued sync job's terminal status via GET /queue/status/:queueId.
+        /// A "queued" admission only means the request was accepted onto the async queue, not that
+        /// the server applied it — see gs-playnite#83, where a job that failed after admission left
+        /// the client believing it had synced. Bounded to a short budget: if the job hasn't reached a
+        /// terminal state in time (large library, slow backend), returns null so the caller falls back
+        /// to the pre-existing behavior of trusting the "queued" admission. This only tightens the
+        /// common case — a job that fails fast (validation error, immediate crash) is now caught
+        /// instead of silently treated as success.
+        /// </summary>
+        /// <returns>true if the job completed successfully, false if it failed/partially applied,
+        /// or null if no terminal status was observed within the budget.</returns>
+        private async Task<bool?> TryConfirmQueueCompletionAsync(string label, string queueId) {
+            if (string.IsNullOrEmpty(queueId)) {
+                return null;
+            }
+
+            var deadline = DateTime.UtcNow + QueueStatusPollBudget;
+            do {
+                await Task.Delay(QueueStatusPollInterval);
+
+                QueueStatusRes res;
+                try {
+                    res = await _apiClient.GetQueueStatus(queueId);
+                }
+                catch (Exception ex) {
+                    _logger.Warn(ex, $"{label}: queue status poll failed for {queueId}");
+                    continue;
+                }
+
+                switch (res?.data?.status) {
+                    case "completed":
+                        return true;
+                    case "partial":
+                    case "failed":
+                        _logger.Error($"{label}: server job {queueId} ended with status={res.data.status}" +
+                            (string.IsNullOrEmpty(res.data.errorMessage) ? "" : $" ({res.data.errorMessage})"));
+                        return false;
+                    default:
+                        // pending / processing / retrying / no response yet — keep waiting.
+                        break;
+                }
+            } while (DateTime.UtcNow < deadline);
+
+            _logger.Info($"{label}: job {queueId} still processing after {QueueStatusPollBudget.TotalSeconds:F0}s — " +
+                "committing baseline optimistically (server may still be working on a large library).");
+            return null;
+        }
+
         /// <summary>
         /// Sends the full library via v4 chunked sync and writes the local hash index.
         /// </summary>
@@ -630,6 +689,10 @@ namespace GsPlugin.Services {
                 }
 
                 if (response.success && response.status == "queued") {
+                    if (await TryConfirmQueueCompletionAsync("Full library sync", response.queueId) == false) {
+                        return SyncLibraryResult.Error;
+                    }
+
                     _logger.Info($"Full library sync queued ({library.Count} games).");
 
                     var indexDict = library.ToDictionary(
@@ -813,6 +876,10 @@ namespace GsPlugin.Services {
                 }
 
                 if (response.success && response.status == "queued") {
+                    if (await TryConfirmQueueCompletionAsync("Library diff sync", response.queueId) == false) {
+                        return SyncLibraryResult.Error;
+                    }
+
                     _logger.Info("Library diff sync queued successfully.");
 
                     var upserted = added.Concat(updated).ToDictionary(
@@ -947,6 +1014,10 @@ namespace GsPlugin.Services {
                 }
 
                 if (response.success && response.status == "queued") {
+                    if (await TryConfirmQueueCompletionAsync("Full achievements sync", response.queueId) == false) {
+                        return SyncLibraryResult.Error;
+                    }
+
                     _logger.Info("Full achievements sync queued successfully.");
 
                     var indexDict = games.ToDictionary(
@@ -1162,6 +1233,10 @@ namespace GsPlugin.Services {
                 }
 
                 if (response.success && response.status == "queued") {
+                    if (await TryConfirmQueueCompletionAsync("Achievement diff sync", response.queueId) == false) {
+                        return SyncLibraryResult.Error;
+                    }
+
                     _logger.Info("Achievement diff sync queued successfully.");
 
                     if (!GsSyncHashIndex.ApplyAchievementDiff(upsertedFingerprints, allCleared)) {


### PR DESCRIPTION
## Summary
- A `queued` response only means the request was admitted onto the async queue, not that the server applied it — see #83, where a job that failed after admission left the client believing it had synced.
- Adds `GET /api/playnite/queue/status/:queueId` support and polls it (1.5s cadence, 8s budget matching the server's documented "1-5 seconds" processing time) before committing the local hash index / `LastSyncAt` baseline, across all four "queued" paths: full/diff library sync, full/diff achievements sync.
- Bounded and best-effort by design: if the job hasn't reached a terminal state within the budget (large library, slow backend), falls back to the pre-existing trust-on-`queued` behavior rather than blocking the startup/library-updated callbacks that `await` these sync methods.

Backend counterpart: game-scrobbler/gs-mono#70 (makes the library upsert itself atomic).

## Test plan
- [x] MSBuild Release build succeeds
- [x] `dotnet test` — 325/325 pass