### PR TITLE
fix(hooks): make the commit-msg case checks case-sensitive

### DIFF
--- a/hooks/commit-msg.ps1
+++ b/hooks/commit-msg.ps1
@@ -1,4 +1,4 @@
-# PowerShell commit-msg hook for Conventional Commits validation
+﻿# PowerShell commit-msg hook for Conventional Commits validation
 # This script validates that commit messages follow the Conventional Commits specification
 # See: https://www.conventionalcommits.org/
 
@@ -17,14 +17,17 @@ if (-not (Test-Path $CommitMsgFile)) {
 
 $commitMsg = Get-Content $CommitMsgFile -Raw
 
-# Skip validation for merge commits
-if ($commitMsg -match "^Merge") {
+# Skip validation for the merge and revert commits git generates itself, which are
+# always capitalized.
+# -cmatch, not -match: PowerShell's -match is case-INSENSITIVE, so these guards
+# also fired on lowercase text. A conventional "revert: undo X" commit skipped
+# validation entirely because of it.
+if ($commitMsg -cmatch "^Merge") {
     Write-Host "Merge commit detected, skipping validation." -ForegroundColor Green
     exit 0
 }
 
-# Skip validation for revert commits
-if ($commitMsg -match "^Revert") {
+if ($commitMsg -cmatch "^Revert") {
     Write-Host "Revert commit detected, skipping validation." -ForegroundColor Green
     exit 0
 }
@@ -34,8 +37,11 @@ if ($commitMsg -match "^Revert") {
 # Optional: body and footer with BREAKING CHANGE
 $conventionalCommitPattern = '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.+\))?(!)?:\s.+'
 
-# Check if commit message matches the pattern
-if ($commitMsg -notmatch $conventionalCommitPattern) {
+# Check if commit message matches the pattern.
+# -cnotmatch, not -notmatch: the type must be lowercase. Case-insensitive matching
+# accepted "Feat: x" here, which release-please does not parse as a release-worthy
+# commit, so the version bump would go missing with nothing reporting an error.
+if ($commitMsg -cnotmatch $conventionalCommitPattern) {
     Write-Host "" -ForegroundColor White
     Write-Host "============================================" -ForegroundColor Red
     Write-Host "  COMMIT MESSAGE DOES NOT FOLLOW" -ForegroundColor Red
@@ -84,8 +90,11 @@ $firstLine = ($commitMsg -split "`n")[0]
 $description = ($firstLine -split ':\s+', 2)[1]
 
 if ($description) {
-    # Check if description starts with uppercase (should be lowercase)
-    if ($description -match '^[A-Z]') {
+    # Check if description starts with uppercase (should be lowercase).
+    # -cmatch, not -match: with -match this '^[A-Z]' test is true for EVERY
+    # description, so the warning fired on correctly-lowercased subjects and
+    # became noise everyone learned to ignore.
+    if ($description -cmatch '^[A-Z]') {
         Write-Host "" -ForegroundColor White
         Write-Host "Warning: Commit description should start with lowercase letter" -ForegroundColor Yellow
         Write-Host "Current: $description" -ForegroundColor Gray


### PR DESCRIPTION
## The bug

PowerShell's `-match` and `-notmatch` are **case-insensitive by default**. The
case-sensitive forms are `-cmatch` / `-cnotmatch`. All three case-dependent
checks in `hooks/commit-msg.ps1` used the insensitive form, so each was testing
the opposite of what it reads as.

The regexes are all correct. The defect is in the operator, which is why this
survived review: nothing looks wrong with `'^[A-Z]'`.

## What was actually broken

**1. The warning that fired on every commit (visible, harmless)**

```powershell
if ($description -match '^[A-Z]') {   # true for EVERY description
```

Every commit printed "Warning: Commit description should start with lowercase
letter" regardless of the subject. The 13 commits merged in #92 all triggered it
on correctly-lowercased subjects. A warning that always fires is a warning people
learn to read past, which is a fair part of why the next one went unnoticed.

**2. Uppercase commit types passed validation (invisible, consequential)**

```powershell
if ($commitMsg -notmatch $conventionalCommitPattern) {   # accepted "Fix: x"
```

`Fix: something` and `FEAT: something` were accepted. release-please parses types
case-sensitively and does not recognize them, so such a commit is dropped from
the changelog **and from the version bump**, with nothing anywhere reporting an
error. Given this repo has already had a release pipeline fail quietly once, a
commit type that release tooling ignores is worth rejecting at commit time.

This is the one behavior change in the PR: `Fix: x` now fails the hook. That is
the intent of the check as written and matches CLAUDE.md, which already
documents lowercase conventional types.

**3. `revert:` commits skipped validation entirely**

```powershell
if ($commitMsg -match "^Revert") {   # also matched "revert: undo X"
```

The `^Merge` / `^Revert` guards exist for the commits git generates itself, which
are always capitalized. Matching case-insensitively meant a conventional
`revert: undo X` commit hit the skip path instead of being validated.

## The fix

All three switched to `-cmatch` / `-cnotmatch`, each with a comment saying why
the case-sensitive operator is required. The comments matter here: `-match` is
exactly the kind of thing a later reader would "simplify" back to, reintroducing
all three bugs at once.

## Verification

Ran the hook directly against a message matrix:

| Message | Result |
| --- | --- |
| `fix: hook probe` | passes, **no spurious warning** |
| `refactor(api): extract helpers` | passes, no warning |
| `Fix: uppercase type` | **rejected** (was silently accepted) |
| `fix: Uppercase description` | passes with the lowercase warning, correctly |
| `revert: undo the thing` | **validated** (was skipped) |
| `Merge pull request #92 from x/y` | skipped, as intended |
| `Revert "fix: something"` | skipped, as intended |
| `no type at all` | rejected |
| `fix: trailing period.` | passes with the period warning, unaffected |

The commit in this PR is its own smallest demonstration: its hook output shows
`Commit message format is valid!` with no lowercase warning attached.

## Note on how this surfaced

While working #92 the pre-commit format hook was also printing "dotnet format
crashed ... Skipping format check" and then "Code formatting check passed!" on
every commit. That one turned out **not** to be a repo bug: `hooks/` is copied
into `.git/hooks/` by `scripts/setup-hooks.ps1` and nothing re-copies on pull, so
the locally installed copy was several commits behind the fix already made in
`562af21` / `4566ec3`. Re-running `scripts/setup-hooks.ps1` restored it, and the
reinstalled hook was confirmed to reject a deliberately misformatted file rather
than skip. No repo change needed for that, but it is worth knowing that a stale
installed hook fails open while printing "passed".
