### PR TITLE
fix: harden session recovery, sync integrity, and telemetry privacy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,15 @@ jobs:
           SENTRY_PROJECT: gs-playnite
         run: |
           npm install -g @sentry/cli@2.42.2
-          $version = "${{ steps.release.outputs.tag_name }}".TrimStart('v')
+          $assemblyVersion = [System.Reflection.AssemblyName]::GetAssemblyName("$Env:GITHUB_WORKSPACE\bin\Release\GsPlugin.dll").Version
+          $version = $assemblyVersion.ToString(3)
+          if ("${{ steps.release.outputs.tag_name }}" -ne "GsPlugin-v$version") {
+            throw "Release tag does not match the built plugin version $version"
+          }
+          $pdb = [System.IO.File]::ReadAllBytes("$Env:GITHUB_WORKSPACE\bin\Release\GsPlugin.pdb")
+          if ($pdb.Length -lt 4 -or [System.Text.Encoding]::ASCII.GetString($pdb, 0, 4) -ne 'BSJB') {
+            throw 'The plugin PDB must use the portable format expected by the symbol upload'
+          }
           sentry-cli releases new "GsPlugin@$version"
           sentry-cli releases set-commits "GsPlugin@$version" --auto
           sentry-cli upload-dif --type=portablepdb "$Env:GITHUB_WORKSPACE\bin\Release" --log-level=info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,21 @@ jobs:
       - name: Run Tests
         run: dotnet test GsPlugin.Tests\GsPlugin.Tests.csproj --configuration Release --no-build --verbosity normal
 
+      # scripts/update-installer-manifest.ps1 and scripts/generate-release-highlights.ps1 drive the
+      # release pipeline: the manifest Playnite reads for update discovery, and the user-facing
+      # changelog. Both ship Pester suites that no workflow was running, so a break in either could
+      # only be found in production. Pester is version-pinned so a gallery release cannot change
+      # what CI enforces.
+      - name: Run PowerShell Script Tests (Pester)
+        run: |
+          Install-Module Pester -RequiredVersion 5.6.1 -Force -SkipPublisherCheck -Scope CurrentUser
+          Import-Module Pester -RequiredVersion 5.6.1
+          $cfg = New-PesterConfiguration
+          $cfg.Run.Path = 'scripts'
+          $cfg.Run.Exit = $true
+          $cfg.Output.CIFormat = 'GithubActions'
+          Invoke-Pester -Configuration $cfg
+
       - name: Setup Playnite
         run: |
           Invoke-WebRequest -Uri "https://github.com/JosefNemec/Playnite/releases/download/${{ env.PLAYNITE_VERSION }}/${{ env.PLAYNITE_ZIP }}" -OutFile "$Env:GITHUB_WORKSPACE\Playnite.zip"

--- a/Api/Dtos.cs
+++ b/Api/Dtos.cs
@@ -249,6 +249,13 @@ namespace GsPlugin.Api {
     public class AchievementItemDto {
         public string name { get; set; }
         public string description { get; set; }
+
+        // Not part of any hash recipe, but the providers disagree on DateTimeKind: SuccessStory's
+        // ISO strings yield Utc, while a bare timestamp from the Playnite Achievements SQLite cache
+        // yields Unspecified. Without the converter the same field reaches the server as "...Z",
+        // "...+02:00" or an ambiguous "..." depending on which addon supplied it. Normalize so an
+        // unlock time means one thing.
+        [JsonConverter(typeof(CanonicalDateTimeConverter))]
         public DateTime? date_unlocked { get; set; }
         public bool is_unlocked { get; set; }
         public float? rarity_percent { get; set; }

--- a/Api/GsApiClient.cs
+++ b/Api/GsApiClient.cs
@@ -53,6 +53,20 @@ namespace GsPlugin.Api {
                     Timeout = TimeSpan.FromSeconds(30)
                 };
             }
+
+            // The server reads this on every token-authenticated request to populate
+            // playnite_users.plugin_version. Setting it as a default header covers registration,
+            // all v3/v4 writes, notifications and the dashboard token in one place; without it,
+            // version telemetry only exists for users who happen to open the sidebar.
+            // Guarded because a throw in a static constructor is unrecoverable: it would surface as
+            // TypeInitializationException on every later access to this type.
+            try {
+                _defaultHttpClient.DefaultRequestHeaders.Add(
+                    "x-playnite-plugin-version", GsSentry.GetPluginVersion());
+            }
+            catch (Exception ex) {
+                GsLogger.Warn($"Could not set plugin version header: {ex.Message}");
+            }
         }
 
         private readonly HttpClient _httpClient;

--- a/Api/GsApiClient.cs
+++ b/Api/GsApiClient.cs
@@ -65,14 +65,15 @@ namespace GsPlugin.Api {
         /// Constructor that accepts a custom HttpClient for testing.
         /// Production code uses the parameterless constructor which provides the shared Sentry-traced client.
         /// </summary>
-        internal GsApiClient(HttpClient httpClient) : this(httpClient, false) { }
+        internal GsApiClient(HttpClient httpClient, GsCircuitBreaker circuitBreaker = null)
+            : this(httpClient, false, circuitBreaker) { }
 
-        private GsApiClient(HttpClient httpClient, bool enableRecoveryFlush) {
+        private GsApiClient(HttpClient httpClient, bool enableRecoveryFlush, GsCircuitBreaker circuitBreaker = null) {
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             _jsonOptions = new JsonSerializerOptions {
                 PropertyNameCaseInsensitive = true
             };
-            _circuitBreaker = new GsCircuitBreaker(
+            _circuitBreaker = circuitBreaker ?? new GsCircuitBreaker(
                 failureThreshold: 3,
                 timeout: TimeSpan.FromMinutes(2),
                 retryDelay: TimeSpan.FromSeconds(10));
@@ -122,7 +123,10 @@ namespace GsPlugin.Api {
 
         #region Game Session Management
 
-        public async Task<ScrobbleStartRes> StartGameSession(ScrobbleStartReq startData) {
+        public Task<ScrobbleStartRes> StartGameSession(ScrobbleStartReq startData) =>
+            StartGameSession(startData, null);
+
+        private async Task<ScrobbleStartRes> StartGameSession(ScrobbleStartReq startData, Action onAttempt) {
             // Validate input before making API call
             if (!RequireRequest(startData, nameof(StartGameSession), "startData") ||
                 !RequireIdentity(startData.user_id, nameof(StartGameSession))) {
@@ -136,6 +140,7 @@ namespace GsPlugin.Api {
             string url = $"{_apiBaseUrl}/api/playnite/v3/scrobble/start";
 
             var envelope = await _circuitBreaker.ExecuteAsync(async () => {
+                onAttempt?.Invoke();
                 return await PostJsonAsync<ApiResponse<ScrobbleStartData>>(url, startData);
             }, maxRetries: 2, isFailure: r => r == null);
 
@@ -165,7 +170,10 @@ namespace GsPlugin.Api {
             }
         }
 
-        public async Task<ScrobbleFinishRes> FinishGameSession(ScrobbleFinishReq endData) {
+        public Task<ScrobbleFinishRes> FinishGameSession(ScrobbleFinishReq endData) =>
+            FinishGameSession(endData, null);
+
+        private async Task<ScrobbleFinishRes> FinishGameSession(ScrobbleFinishReq endData, Action onAttempt) {
             // Validate input before making API call
             if (!RequireRequest(endData, nameof(FinishGameSession), "endData")) {
                 return null;
@@ -210,6 +218,7 @@ namespace GsPlugin.Api {
             string url = $"{_apiBaseUrl}/api/playnite/v3/scrobble/finish";
 
             var envelope = await _circuitBreaker.ExecuteAsync(async () => {
+                onAttempt?.Invoke();
                 return await PostJsonAsync<ApiResponse<ScrobbleFinishData>>(url, sendData, true);
             }, maxRetries: 2, isFailure: r => r == null);
 
@@ -261,6 +270,17 @@ namespace GsPlugin.Api {
             }
 
             try {
+                // An open circuit fast-fails every send without touching the network, but the loop
+                // below cannot tell that from a real rejection and would still increment
+                // FlushAttempts. Five such passes (~25 minutes offline, or five launches) would
+                // drop the entire queue for data that would have synced fine once connectivity
+                // returned. Skip only while the cooldown is active; after it expires this flush
+                // must itself be able to probe the server, even when no other API calls occur.
+                if (_circuitBreaker.IsBlocking) {
+                    _logger.Info("Skipping pending-scrobble flush: circuit breaker is open");
+                    return;
+                }
+
                 // Peek without clearing: items remain persisted until individually confirmed.
                 var pending = GsDataManager.PeekPendingScrobbles();
                 if (pending == null || pending.Count == 0) {
@@ -273,14 +293,25 @@ namespace GsPlugin.Api {
                     // Re-check opt-out before each send (user may have opted out mid-flush)
                     if (GsDataManager.IsOptedOut) break;
 
+                    // The breaker can trip partway through a pass: the first real send fails and
+                    // opens it, then every remaining item fast-fails with no network call. Stop
+                    // rather than burning an attempt per item on a circuit we already know is open.
+                    if (_circuitBreaker.IsBlocking) {
+                        _logger.Info("Stopping pending-scrobble flush: circuit breaker opened mid-pass");
+                        break;
+                    }
+
                     bool success = false;
+                    bool attempted = false;
+                    string startedSessionId = null;
                     try {
                         if (item.Type == "start" && item.StartData != null) {
-                            var res = await StartGameSession(item.StartData);
+                            var res = await StartGameSession(item.StartData, () => attempted = true);
                             success = res != null;
+                            startedSessionId = res?.session_id;
                         }
                         else if (item.Type == "finish" && item.FinishData != null) {
-                            var res = await FinishGameSession(item.FinishData);
+                            var res = await FinishGameSession(item.FinishData, () => attempted = true);
                             success = res != null;
                         }
                         else {
@@ -295,10 +326,21 @@ namespace GsPlugin.Api {
                     }
 
                     if (success) {
-                        // Remove from the persisted queue now that the server has accepted it.
-                        GsDataManager.RemovePendingScrobble(item);
+                        // Persist replay pairing before removing a start, so a crash cannot lose
+                        // its returned session id and let the finish target another open session.
+                        bool persisted = item.Type == "start"
+                            ? GsDataManager.CompletePendingStart(item, startedSessionId)
+                            : GsDataManager.CompletePendingScrobble(item);
+                        if (!persisted) {
+                            break;
+                        }
                     }
                     else {
+                        // Another request may open the circuit after our entry check. A fast-fail
+                        // in that window is not a failed send and must not consume the retry budget.
+                        if (!attempted && _circuitBreaker.IsBlocking) {
+                            break;
+                        }
                         // Mutate-then-save under GsDataManager's lock, rather than incrementing
                         // the field directly and calling Save() separately — keeps this in line
                         // with every other queue mutation (see RemovePendingScrobble) instead of
@@ -306,8 +348,7 @@ namespace GsPlugin.Api {
                         GsDataManager.IncrementPendingScrobbleFlushAttempts(item);
                         if (item.FlushAttempts >= MaxFlushAttempts) {
                             _logger.Warn($"Dropping pending scrobble after {item.FlushAttempts} failed flush attempts (type={item.Type}, queued={item.QueuedAt:O})");
-                            GsDataManager.RemovePendingScrobble(item);
-                            GsDataManager.MutateAndSave(d => d.DroppedScrobbleCount++);
+                            GsDataManager.DropPendingScrobble(item);
                             GsSentry.AddBreadcrumb(
                                 message: $"Dropped pending scrobble after {MaxFlushAttempts} attempts",
                                 category: "flush",
@@ -318,6 +359,10 @@ namespace GsPlugin.Api {
                         }
                         // else: item stays in the queue with its incremented FlushAttempts counter,
                         // already persisted by IncrementPendingScrobbleFlushAttempts above.
+                        // Keep FIFO order: a finish must never overtake its failed start, even if
+                        // that start failed permanently without opening the circuit. Terminally
+                        // dropped starts also drop their dependent finish in the same persisted edit.
+                        break;
                     }
                 }
             }
@@ -448,7 +493,8 @@ namespace GsPlugin.Api {
             return await _circuitBreaker.ExecuteAsync(
                 async () => {
                     lastStatus = 0;
-                    return await PostJsonAsync<TRes>(url, req, true, status => lastStatus = status);
+                    return await PostJsonAsync<TRes>(url, req, true, status => lastStatus = status,
+                        parseErrorBody: true);
                 },
                 maxRetries: 1,
                 isFailure: r => r == null,
@@ -875,8 +921,18 @@ namespace GsPlugin.Api {
         /// </summary>
         private const int MaxLoggedBodyChars = 512;
 
+        /// <param name="parseErrorBody">
+        /// When true, a permanent 4xx whose body deserializes into <typeparamref name="TResponse"/>
+        /// is returned instead of null. Transient HTTP errors always stay retryable failures.
+        /// Some rejections are business outcomes rather than failures:
+        /// the v4 commit answers a snapshot-hash mismatch with HTTP 400 and
+        /// {status:"force-full-sync", reason:"hash_mismatch"}. Collapsing that to null makes it
+        /// indistinguishable from a dropped connection, leaves the caller's recovery branch
+        /// unreachable, and lets a deterministic rejection count against the shared circuit breaker.
+        /// Opt-in so endpoints whose callers only test for null keep their current behaviour.
+        /// </param>
         private async Task<TResponse> PostJsonAsync<TResponse>(string url, object payload, bool ensureSuccess = false,
-            Action<int> onStatus = null)
+            Action<int> onStatus = null, bool parseErrorBody = false)
             where TResponse : class {
             string jsonData = JsonSerializer.Serialize(payload, _jsonOptions);
 
@@ -930,6 +986,26 @@ namespace GsPlugin.Api {
                                 $"Request failed with status {(int)response.StatusCode} ({response.StatusCode}) for URL {url}");
 
                             CaptureHttpException(httpEx, url, jsonData, response, responseBody);
+                        }
+
+                        // Keep recognized permanent business rejections (e.g. force-full-sync)
+                        // inspectable, but never turn JSON from a 408/429/5xx into circuit success.
+                        if (parseErrorBody && IsPermanentRejection((int)response.StatusCode)
+                            && !string.IsNullOrWhiteSpace(responseBody)) {
+                            var errorContentType = response?.Content?.Headers?.ContentType?.MediaType;
+                            if (errorContentType == null || !errorContentType.Contains("html")) {
+                                try {
+                                    var errorResponse =
+                                        JsonSerializer.Deserialize<TResponse>(responseBody, _jsonOptions);
+                                    if (errorResponse != null) {
+                                        return errorResponse;
+                                    }
+                                }
+                                catch (JsonException) {
+                                    // Not a shape we understand — fall through to the null result so the
+                                    // caller still treats it as a failure rather than a parsed outcome.
+                                }
+                            }
                         }
                         return null;
                     }

--- a/Api/GsApiClient.cs
+++ b/Api/GsApiClient.cs
@@ -829,18 +829,28 @@ namespace GsPlugin.Api {
             GsSentry.CaptureException(exception, contextMessage);
         }
 
+        /// <summary>
+        /// Captures a scrobble failure. The message is the Sentry issue fingerprint, so game name,
+        /// user id and session id are attached as a breadcrumb rather than interpolated into it:
+        /// putting a game title in the title split one failure mode into a separate issue per game
+        /// (making the real rate invisible) and published a per-title event stream nobody asked for.
+        /// The context is still available on the event, just not as its identity.
+        /// </summary>
         private static void CaptureSentryMessage(string message, SentryLevel level, string gameName = null, string userId = null, string sessionId = null) {
-            string contextMessage = message;
+            var data = new Dictionary<string, string>();
             if (!string.IsNullOrEmpty(gameName)) {
-                contextMessage += $" [Game: {gameName}]";
+                data["game"] = gameName;
             }
             if (!string.IsNullOrEmpty(userId)) {
-                contextMessage += $" [User: {userId}]";
+                data["user_id"] = userId;
             }
             if (!string.IsNullOrEmpty(sessionId)) {
-                contextMessage += $" [Session: {sessionId}]";
+                data["session_id"] = sessionId;
             }
-            GsSentry.CaptureMessage(contextMessage, level);
+            if (data.Count > 0) {
+                GsSentry.AddBreadcrumb(message: "scrobble failure context", category: "scrobble", data: data);
+            }
+            GsSentry.CaptureMessage(message, level);
         }
 
         private async Task<TResponse> GetJsonAsync<TResponse>(string url) where TResponse : class {

--- a/Api/GsCircuitBreaker.cs
+++ b/Api/GsCircuitBreaker.cs
@@ -51,6 +51,19 @@ namespace GsPlugin.Api {
         }
 
         /// <summary>
+        /// True while the open-circuit cooldown still prevents a request. Once the cooldown
+        /// expires, a caller must be allowed into ExecuteAsync to probe for recovery; merely
+        /// reading State never transitions the circuit out of Open.
+        /// </summary>
+        internal bool IsBlocking {
+            get {
+                lock (_lock) {
+                    return _state == CircuitState.Open && DateTime.UtcNow - _lastFailureTime < _timeout;
+                }
+            }
+        }
+
+        /// <summary>
         /// Executes a function with circuit breaker protection and retry logic.
         /// </summary>
         /// <typeparam name="T">Return type of the function</typeparam>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ GsPlugin (entry point, IDisposable)
 - **Local baselines:** `gs_library_hashes.json` / `gs_achievement_hashes.json` store `{ playnite_id → fingerprint }` only. Library fingerprint = `playtime|play_count|normalized_last_activity|metadata_hash`. The local achievement fingerprint hashes each sorted `name + unlock state + rounded rarity` tuple, so rarity-only changes and same-count unlock swaps are detected. Global `LastLibraryHash` / `LastAchievementHash` in `gs_data.json` remain the server `result_snapshot_hash` / `base_snapshot_hash` values (`createLibraryHashV3` / `createAchievementHashV2` recipes — unchanged); do not substitute the richer local achievement recipe for this server contract.
 - **Hashed values must serialize exactly as hashed.** `result_snapshot_hash` can only be recomputed from the payload, so anything feeding the hash has to go on the wire in its hashed form. `GameSyncDto`'s three date fields carry `[JsonConverter(typeof(CanonicalDateTimeConverter))]` for this reason: System.Text.Json preserves `DateTimeKind` and would otherwise emit `2025-02-19T14:51:26.897-08:00` for a value hashed as `2025-02-19T22:51:26Z`, leaving the recipient to infer a normalization the payload never states. Never add a `DateTime` to a hashed DTO without the converter, and land any recipe change in `GsPlugin.Tests/Fixtures/playnite-hash-vectors.json`, whose twin in the backend repo asserts the same digests.
 - **Permanent rejections are not retried.** `PostV4Async` passes `isPermanent` to the circuit breaker so a 4xx (other than 408/429) returns immediately and does not count toward the failure threshold — retrying cannot change the answer, and letting it trip the breaker takes scrobbles down with it. Such a response still marks the service responsive, so it resolves a HalfOpen probe rather than leaving the breaker mid-probe.
-- **Commit order (anti force-full-sync loop):** on `queued`, persist the hash index for **all** items first, then write `Last*Hash`. On any chunk/commit failure → abort session; **do not** update index or global hash. Mid-failure leaves the previous good baseline intact.
+- **Commit order:** a `queued` response is admission, not completion. Poll for `completed` before saving the index and then `Last*Hash`. Failed/partial jobs, missing job IDs, unavailable status, and jobs still pending after the bounded poll retain the prior baseline and return an error so the next sync retries. No pending-job reconciliation is persisted. The captured install identity/generation fences both baseline writes against deletion or rotation during the request.
 - This invariant is enforced in exactly one place: `GsScrobblingService.CommitSyncBaselineAsync(label, queueId, persistIndex, persistHashes)`. All four sync paths (library full/diff, achievements full/diff) route through it, so do not re-implement the confirm-then-index-then-hash sequence at a call site. `SkipOrRepairIndex` likewise owns the "hash matches but index count diverged" repair for all three paths.
 - **Migration:** if the shipped legacy `gs_snapshot.json` exists, `GsSyncHashIndex.Initialize` derives fingerprints once, writes the compact files, and deletes the fat snapshot.
 - **Crash recovery:** `GsAtomicFile` promotes a surviving `.tmp` when the destination is missing and performs JSON replacement with bounded retries for transient Windows file locks. Both `GsDataManager` and `GsSyncHashIndex` use it.
@@ -122,9 +122,11 @@ GsPlugin (entry point, IDisposable)
 - Two user-facing settings (`ShowUpdateNotifications`, `ShowImportantNotifications`) control whether update and server notifications appear. Both default to `true` and are synced to `GsData` via `GsPluginSettingsViewModel.EndEdit()` and `LoadExistingSettings()`.
 
 ### Pending Scrobble Flush
-- Flush uses a peek-then-remove strategy: `PeekPendingScrobbles()` returns a snapshot without clearing, each item stays on disk until its send is confirmed, then `RemovePendingScrobble()` removes it atomically. A mid-flush crash loses nothing.
+- Starts and stops are persisted before waiting for HTTP. Per-game gates serialize live requests; process-local queue claims prevent replay from duplicating those requests. `PeekPendingScrobbles()` returns only the unclaimed prefix so finishes cannot overtake a pending start. Claims disappear on restart.
+- Successful starts atomically attach their session ID to the matching queued finish, stopping at the next start for that game. Accepted starts without a session ID retain the pending marker when no finish exists. Finish completion clears only a matching active session. Failed queue writes roll back local transitions.
+- Shutdown persists all active and pending-start finishes in one identity-checked write before the first network await.
 - `_flushInFlight` Interlocked guard prevents concurrent flush invocations (circuit recovery + periodic timer + startup can overlap).
-- Failed items stay in the queue with an incremented `FlushAttempts` counter (persisted via `Save()`) and are dropped after `MaxFlushAttempts` (5).
+- Failed items stay queued with an incremented `FlushAttempts` counter. A blocked circuit consumes no attempt; an expired open circuit permits a recovery probe. A failed send stops the pass, and dropping a start after five attempts also drops its paired finish before the next same-game start.
 - A periodic 5-minute timer (`_pendingFlushTimer`) retries queued scrobbles independently of circuit breaker recovery. Disposed in `Dispose()`.
 
 ### Startup Flow
@@ -155,6 +157,7 @@ GsPlugin (entry point, IDisposable)
 ### Achievement Provider Architecture
 Achievement data comes from two optional addons via an aggregator pattern:
 - `IAchievementProvider` — common interface (`GetCounts`, `GetAchievements`, `IsInstalled`)
+- `IReliableAchievementProvider.ReadAchievements` reports successful reads (including confirmed empty results) separately from unavailable data. The aggregator preserves failures from the preferred provider, and full/diff achievement sync aborts an unavailable snapshot without changing the baseline.
 - `AchievementProviderBase` — abstract base both providers derive from. Owns the plugin `Guid`, `IsPluginLoaded`, `IsInstalled` (delegating to an abstract `HasLocalData`), the single `GetVersion()` implementation, and the `SafeRead`/`SafeReadValue` wrappers that log and return null on failure. Subclasses contain only their real read logic. `LogPrefix` is derived from `GetType().Name`, so each provider keeps its own log prefix without duplicating the literal.
 - `GsSuccessStoryHelper` — reads SuccessStory's per-game JSON files from `{ExtensionsDataPath}/{pluginGuid}/SuccessStory/{gameId}.json` (priority 1)
 - `GsPlayniteAchievementsHelper` — reads Playnite Achievements' SQLite database at `{ExtensionsDataPath}/{pluginGuid}/achievement_cache.db` via `System.Data.SQLite` in read-only mode (priority 2)
@@ -192,7 +195,8 @@ Achievement data comes from two optional addons via an aggregator pattern:
 
 ### Thread-Safe Data Mutations
 - Use `GsDataManager.MutateAndSave(d => { ... })` instead of directly modifying `GsDataManager.Data` fields followed by `GsDataManager.Save()`. The `MutateAndSave` method acquires the lock, executes the action, and persists atomically — preventing concurrent threads from interleaving mutations.
-- Direct field access via `GsDataManager.Data` is still available for reads, but all write-then-save sequences should use `MutateAndSave`.
+- Direct field access via `GsDataManager.Data` is still available for reads, but all write-then-save sequences should use `MutateAndSave`. Identity-bound asynchronous completions use `TryMutateIfActiveIdentity`; its persistence failure restores the prior state.
+- Initialization retries transient read failures and throws if existing data remains unreadable or invalid. It preserves the file, leaves data unavailable, and stops plugin construction before registration or telemetry. Only a missing file creates a fresh installation.
 
 ### API DTOs
 - All API request/response DTOs live in `Api/Dtos.cs` at namespace level (`GsPlugin.Api`), not nested inside `GsApiClient`. Reference them directly (e.g., `new ScrobbleStartReq { ... }`) — no `GsApiClient.` prefix needed.
@@ -215,7 +219,8 @@ Hook scripts in `hooks/` are installed to `.git/hooks/` via `scripts/setup-hooks
 - All `SentrySdk` calls are wrapped in try/catch so the plugin continues working if the Sentry SDK is unavailable (e.g., expired account). `GsApiClient` similarly falls back to a plain `HttpClient` if `SentryHttpMessageHandler` throws.
 - `MaxBreadcrumbs` is capped at 50 (default 100) to reduce per-session memory overhead.
 - Continuous profiling and failed-request capture are disabled to avoid background-worker shutdown hangs and cross-extension `HttpStatusCodeRange` version conflicts. Trace sampling is 10% when telemetry is enabled.
-- Plugin disposal calls `GsSentry.Shutdown()`, which performs a two-second bounded flush before closing. It is safe to call after failed initialization.
+- Telemetry starts after saved preferences are loaded. Settings save, deletion, and opt-in reconcile SDK lifetimes. Consent handlers check every outgoing batch, including automatic sessions; a retired SDK lifetime stays revoked even after preferences are re-enabled.
+- Plugin disposal calls `GsSentry.Shutdown()`, which disposes only its owned initialization handle with a two-second shutdown timeout. It does not globally flush or close another addon's newer hub. Global exception handlers are unsubscribed on shutdown.
 - `scripts/resolve-legacy-sentry-issues.ps1` is the maintenance helper for resolving legacy Sentry issues; use `-WhatIf` before applying changes.
 
 ### Playnite SDK Type Gotchas

--- a/GsPlugin.Tests/AccountLinkingConcurrencyTests.cs
+++ b/GsPlugin.Tests/AccountLinkingConcurrencyTests.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Runtime.Remoting.Messaging;
+using System.Runtime.Remoting.Proxies;
+using System.Threading;
+using System.Threading.Tasks;
+using GsPlugin.Api;
+using GsPlugin.Models;
+using GsPlugin.Services;
+using Playnite.SDK;
+using Xunit;
+
+namespace GsPlugin.Tests {
+    [Collection("StaticManagerTests")]
+    public class AccountLinkingConcurrencyTests {
+        private sealed class DelayedHttpHandler : HttpMessageHandler {
+            private readonly TaskCompletionSource<HttpResponseMessage> _firstResponse =
+                new TaskCompletionSource<HttpResponseMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+            public TaskCompletionSource<bool> FirstRequest { get; } =
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            public int CallCount;
+            public string LaterResponse { get; set; } = "{\"success\":true,\"userId\":\"new-account\"}";
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+                if (Interlocked.Increment(ref CallCount) == 1) {
+                    FirstRequest.TrySetResult(true);
+                    return _firstResponse.Task;
+                }
+                return Task.FromResult(Response(LaterResponse));
+            }
+
+            public void CompleteFirst(string json) => _firstResponse.TrySetResult(Response(json));
+
+            private static HttpResponseMessage Response(string json) => new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+            };
+        }
+
+        // Only unlink confirmation is used. A remoting proxy avoids adding a mocking dependency
+        // or implementing the entire Playnite API just to return Yes from its dialog service.
+        private sealed class ConfirmingPlayniteProxy : RealProxy {
+            public ConfirmingPlayniteProxy(Type interfaceType) : base(interfaceType) { }
+
+            public override IMessage Invoke(IMessage message) {
+                var call = (IMethodCallMessage)message;
+                var method = (MethodInfo)call.MethodBase;
+                object result;
+                if (method.Name == "get_Dialogs") {
+                    result = new ConfirmingPlayniteProxy(method.ReturnType).GetTransparentProxy();
+                }
+                else if (method.Name == "ShowMessage") {
+                    result = Enum.Parse(method.ReturnType, "Yes");
+                }
+                else {
+                    return new ReturnMessage(new InvalidOperationException("Unexpected Playnite call: " + method.Name), call);
+                }
+                return new ReturnMessage(result, null, 0, call.LogicalCallContext, call);
+            }
+        }
+
+        private static GsAccountLinkingService CreateService(DelayedHttpHandler handler) =>
+            new GsAccountLinkingService(new GsApiClient(new HttpClient(handler)),
+                (IPlayniteAPI)new ConfirmingPlayniteProxy(typeof(IPlayniteAPI)).GetTransparentProxy());
+
+        [Theory]
+        [InlineData("old-account")]
+        [InlineData("not_linked")]
+        public async Task LinkResponseAfterIdentityRotation_CannotSetOrClearReplacementAccount(string returnedUser) {
+            using (var temp = TempPluginDir.CreateWithDataManagerAndHashIndex()) {
+                var handler = new DelayedHttpHandler();
+                var service = CreateService(handler);
+                var pending = service.LinkAccountAsync("valid-token", LinkingContext.AutomaticUri);
+                await handler.FirstRequest.Task;
+
+                var replacementId = GsDataManager.RotateInstallId();
+                GsDataManager.MutateAndSave(d => d.LinkedUserId = "replacement-account");
+                handler.CompleteFirst("{\"success\":true,\"userId\":\"" + returnedUser + "\"}");
+                var result = await pending;
+
+                Assert.False(result.Success);
+                Assert.Equal(replacementId, GsDataManager.Data.InstallID);
+                Assert.Equal("replacement-account", GsDataManager.Data.LinkedUserId);
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task LinkResponseAfterOptOut_CannotRestoreAccountEvenAfterQuickOptIn(bool optBackIn) {
+            using (var temp = TempPluginDir.CreateWithDataManagerAndHashIndex()) {
+                var handler = new DelayedHttpHandler();
+                var pending = CreateService(handler).LinkAccountAsync("valid-token", LinkingContext.AutomaticUri);
+                await handler.FirstRequest.Task;
+
+                GsDataManager.PerformOptOut();
+                if (optBackIn) {
+                    GsDataManager.PerformOptIn();
+                }
+                handler.CompleteFirst("{\"success\":true,\"userId\":\"old-account\"}");
+                var result = await pending;
+
+                Assert.False(result.Success);
+                Assert.Null(GsDataManager.Data.LinkedUserId);
+                Assert.Equal(!optBackIn, GsDataManager.IsOptedOut);
+            }
+        }
+
+        [Fact]
+        public async Task UnlinkResponseAfterRotation_CannotClearReplacementIdentityState() {
+            using (var temp = TempPluginDir.CreateWithDataManagerAndHashIndex()) {
+                GsDataManager.SetInstallTokenIfActive("valid-token");
+                GsDataManager.MutateAndSave(d => d.LinkedUserId = "old-account");
+                var handler = new DelayedHttpHandler();
+                var pending = CreateService(handler).UnlinkAccountAsync();
+                await handler.FirstRequest.Task;
+
+                GsDataManager.RotateInstallId();
+                GsDataManager.MutateAndSave(d => {
+                    d.LinkedUserId = "replacement-account";
+                    d.LastLibraryHash = "replacement-baseline";
+                    d.ActiveSessionsByGameId["new-game"] = "new-session";
+                });
+                handler.CompleteFirst("{\"success\":true}");
+                var result = await pending;
+
+                Assert.False(result.Success);
+                Assert.Equal("replacement-account", GsDataManager.Data.LinkedUserId);
+                Assert.Equal("replacement-baseline", GsDataManager.Data.LastLibraryHash);
+                Assert.Equal("new-session", GsDataManager.Data.ActiveSessionsByGameId["new-game"]);
+            }
+        }
+
+        [Fact]
+        public async Task ConcurrentLinks_AreSentAndCommittedInOrderAcrossServiceInstances() {
+            using (var temp = TempPluginDir.CreateWithDataManagerAndHashIndex()) {
+                var handler = new DelayedHttpHandler();
+                var first = CreateService(handler).LinkAccountAsync("first-token", LinkingContext.AutomaticUri);
+                await handler.FirstRequest.Task;
+                var second = CreateService(handler).LinkAccountAsync("second-token", LinkingContext.ManualSettings);
+                int sentBeforeFirstCompleted = handler.CallCount;
+
+                handler.CompleteFirst("{\"success\":true,\"userId\":\"first-account\"}");
+                var results = await Task.WhenAll(first, second);
+
+                Assert.Equal(1, sentBeforeFirstCompleted);
+                Assert.All(results, result => Assert.True(result.Success));
+                Assert.Equal(2, handler.CallCount);
+                Assert.Equal("new-account", GsDataManager.Data.LinkedUserId);
+            }
+        }
+
+        [Fact]
+        public async Task LinkWhileUnlinkPending_WaitsUntilUnlinkStateIsCommitted() {
+            using (var temp = TempPluginDir.CreateWithDataManagerAndHashIndex()) {
+                GsDataManager.SetInstallTokenIfActive("valid-token");
+                GsDataManager.MutateAndSave(d => d.LinkedUserId = "old-account");
+                var handler = new DelayedHttpHandler();
+                var service = CreateService(handler);
+                var unlink = service.UnlinkAccountAsync();
+                await handler.FirstRequest.Task;
+                var link = service.LinkAccountAsync("new-token", LinkingContext.AutomaticUri);
+                int sentBeforeUnlinkCompleted = handler.CallCount;
+
+                handler.CompleteFirst("{\"success\":true}");
+                var results = await Task.WhenAll(unlink, link);
+
+                Assert.Equal(1, sentBeforeUnlinkCompleted);
+                Assert.All(results, result => Assert.True(result.Success));
+                Assert.Equal("new-account", GsDataManager.Data.LinkedUserId);
+            }
+        }
+
+        [Fact]
+        public async Task WaitingLinkAfterIdentityRotation_IsRejectedBeforeSending() {
+            using (var temp = TempPluginDir.CreateWithDataManagerAndHashIndex()) {
+                var handler = new DelayedHttpHandler();
+                var service = CreateService(handler);
+                var first = service.LinkAccountAsync("first-token", LinkingContext.AutomaticUri);
+                await handler.FirstRequest.Task;
+                var second = service.LinkAccountAsync("second-token", LinkingContext.ManualSettings);
+
+                GsDataManager.RotateInstallId();
+                handler.CompleteFirst("{\"success\":true,\"userId\":\"old-account\"}");
+                var results = await Task.WhenAll(first, second);
+
+                Assert.All(results, result => Assert.False(result.Success));
+                Assert.Equal(1, handler.CallCount);
+                Assert.Null(GsDataManager.Data.LinkedUserId);
+            }
+        }
+    }
+}

--- a/GsPlugin.Tests/AchievementProviderTests.cs
+++ b/GsPlugin.Tests/AchievementProviderTests.cs
@@ -8,7 +8,7 @@ namespace GsPlugin.Tests {
     /// <summary>
     /// Minimal IAchievementProvider stub for testing the aggregator.
     /// </summary>
-    internal class StubAchievementProvider : IAchievementProvider {
+    internal class StubAchievementProvider : IAchievementProvider, IReliableAchievementProvider {
         public bool IsInstalled { get; set; }
         public bool IsPluginLoaded { get; set; }
         public string ProviderName { get; set; } = "Stub";
@@ -33,6 +33,9 @@ namespace GsPlugin.Tests {
                 return null;
             return list.Count > 0 ? list : null;
         }
+
+        public AchievementReadResult ReadAchievements(Guid gameId) =>
+            AchievementReadResult.Available(GetAchievements(gameId), ProviderName);
     }
 
     public class AchievementItemTests {

--- a/GsPlugin.Tests/CultureInvarianceTests.cs
+++ b/GsPlugin.Tests/CultureInvarianceTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using GsPlugin.Api;
+using GsPlugin.Services;
+using Xunit;
+
+namespace GsPlugin.Tests {
+    /// <summary>
+    /// Guards every value that crosses the wire or feeds a hash against the ambient
+    /// Windows locale.
+    ///
+    /// WHY THIS EXISTS. In a .NET custom format string "-" and ":" are the *date and
+    /// time separator specifiers*, taken from DateTimeFormatInfo.CurrentInfo, and
+    /// "yyyy" renders through CurrentCulture.Calendar. So a timestamp formatted
+    /// without an explicit provider silently becomes 2569-... under th-TH
+    /// (ThaiBuddhist), 1447-11-14 under ar-SA (UmAlQura), and 14.47.53 under fi-FI.
+    /// A hash built from those bytes can never match the server's, and a scrobble
+    /// carrying one cannot be parsed at all -- for every user in those locales,
+    /// permanently, with no error the user or the logs would attribute to locale.
+    ///
+    /// The cultures below are chosen for what each one breaks: a non-Gregorian
+    /// calendar (th-TH, ar-SA), a non-":" time separator (fi-FI), and a locale whose
+    /// casing rules differ (tr-TR).
+    /// </summary>
+    public class CultureInvarianceTests {
+        public static IEnumerable<object[]> HostileCultures() {
+            yield return new object[] { "en-US" };
+            yield return new object[] { "th-TH" };
+            yield return new object[] { "ar-SA" };
+            yield return new object[] { "fi-FI" };
+            yield return new object[] { "tr-TR" };
+        }
+
+        /// <summary>
+        /// Runs <paramref name="body"/> with both CurrentCulture and CurrentUICulture
+        /// swapped, restoring them even if the assertion throws.
+        /// </summary>
+        private static void UnderCulture(string name, Action body) {
+            var thread = Thread.CurrentThread;
+            var prevCulture = thread.CurrentCulture;
+            var prevUiCulture = thread.CurrentUICulture;
+            try {
+                var culture = new CultureInfo(name);
+                thread.CurrentCulture = culture;
+                thread.CurrentUICulture = culture;
+                body();
+            }
+            finally {
+                thread.CurrentCulture = prevCulture;
+                thread.CurrentUICulture = prevUiCulture;
+            }
+        }
+
+        private static readonly DateTime SampleUtc =
+            new DateTime(2026, 5, 1, 14, 47, 53, DateTimeKind.Utc);
+
+        [Theory]
+        [MemberData(nameof(HostileCultures))]
+        public void FormatDateForHash_is_culture_invariant(string culture) {
+            UnderCulture(culture, () =>
+                Assert.Equal("2026-05-01T14:47:53Z", GsHashUtils.FormatDateForHash(SampleUtc)));
+        }
+
+        [Theory]
+        [MemberData(nameof(HostileCultures))]
+        public void FormatScrobbleTimestamp_is_culture_invariant(string culture) {
+            // Local kind so the "K" specifier emits an offset, which is the production shape.
+            var local = new DateTime(2026, 5, 1, 14, 47, 53, DateTimeKind.Local);
+            var expected = GsScrobblingService.FormatScrobbleTimestamp(local);
+            UnderCulture(culture, () => {
+                var actual = GsScrobblingService.FormatScrobbleTimestamp(local);
+                Assert.Equal(expected, actual);
+                // Gregorian year and ":" separators regardless of calendar/locale.
+                Assert.StartsWith("2026-05-01T14:47:53", actual, StringComparison.Ordinal);
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(HostileCultures))]
+        public void Library_hashes_are_culture_invariant(string culture) {
+            var game = new GameSyncDto {
+                playnite_id = "11111111-1111-1111-1111-111111111111",
+                game_name = "Test Game",
+                playtime_seconds = 10,
+                play_count = 20,
+                last_activity = SampleUtc,
+                date_added = SampleUtc,
+                modified = SampleUtc
+            };
+            var expectedMetadata = GsHashUtils.ComputeGameMetadataHash(game);
+            var expectedLibrary = GsHashUtils.ComputeLibraryHash(new List<GameSyncDto> { game });
+
+            UnderCulture(culture, () => {
+                Assert.Equal(expectedMetadata, GsHashUtils.ComputeGameMetadataHash(game));
+                Assert.Equal(expectedLibrary, GsHashUtils.ComputeLibraryHash(new List<GameSyncDto> { game }));
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(HostileCultures))]
+        public void Integration_accounts_hash_is_culture_invariant(string culture) {
+            // Ordinal vs linguistic ordering disagree on these: ordinal puts "Steam"
+            // (S=0x53) before "epic" (e=0x65); a linguistic sort interleaves by letter.
+            var accounts = new List<IntegrationAccountDto> {
+                new IntegrationAccountDto { provider_id = "epic", account_id = "b" },
+                new IntegrationAccountDto { provider_id = "Steam", account_id = "a" },
+                new IntegrationAccountDto { provider_id = "steam", account_id = "I" }
+            };
+            var expected = GsHashUtils.ComputeIntegrationAccountsHash(accounts);
+            UnderCulture(culture, () =>
+                Assert.Equal(expected, GsHashUtils.ComputeIntegrationAccountsHash(accounts)));
+        }
+    }
+}

--- a/GsPlugin.Tests/Fixtures/playnite-hash-vectors.json
+++ b/GsPlugin.Tests/Fixtures/playnite-hash-vectors.json
@@ -83,5 +83,50 @@
     ],
     "metadataHashV3": "6dde75868bbe4679874821267326bfd6e56253664aa36679b7db4a0507993e1e",
     "libraryHashV3": "4d059c3c1e3a07c30ff38bc6e15d3b013f16b8421346ce0dfa1cbfcfaf1f0403"
+  },
+  "achievements": {
+    "$comment": [
+      "Golden vector for createAchievementHashV2 / GsHashUtils.ComputeAchievementHash.",
+      "",
+      "Recipe, per game: {playnite_id}:{count}:{unlockedCount}:{sha256(sortedNames)}",
+      "where sortedNames is the achievement names joined by ',' after an ORDINAL",
+      "(UTF-16 code-unit) sort. Per-game keys are then ordinal-sorted and each is fed",
+      "to SHA-256 as UTF-8 bytes followed by a single '|' byte, including a trailing",
+      "one after the last key.",
+      "",
+      "The names are chosen so ordinal and linguistic sorts DISAGREE: ordinal orders",
+      "by code unit -- 'Z'(0x5A) < '_'(0x5F) < 'a'(0x61) -- giving",
+      "'Zebra,_Secret,apple', while a culture-aware sort would interleave them. A",
+      "vector using only lowercase names would pass under either comparer and prove",
+      "nothing.",
+      "",
+      "The empty-achievement game pins that a game with no achievements still",
+      "contributes a key, hashing the empty string (e3b0c442... is sha256 of '')."
+    ],
+    "games": [
+      {
+        "playnite_id": "22222222-2222-2222-2222-222222222222",
+        "achievements": []
+      },
+      {
+        "playnite_id": "11111111-1111-1111-1111-111111111111",
+        "achievements": [
+          {
+            "name": "Zebra",
+            "is_unlocked": true
+          },
+          {
+            "name": "apple",
+            "is_unlocked": false
+          },
+          {
+            "name": "_Secret",
+            "is_unlocked": true
+          }
+        ]
+      }
+    ],
+    "sortedNames": "Zebra,_Secret,apple",
+    "achievementHashV2": "87486c3e5ad37a1010286d93ee6474a4649e0416d46c5a8c873ef26dce0a14d9"
   }
 }

--- a/GsPlugin.Tests/GsApiClientHttpTests.cs
+++ b/GsPlugin.Tests/GsApiClientHttpTests.cs
@@ -26,6 +26,7 @@ namespace GsPlugin.Tests {
             public HttpRequestMessage LastRequest { get; private set; }
             public string LastRequestBody { get; private set; }
             public int CallCount { get; private set; }
+            public Func<int, HttpResponseMessage> ResponseFactory { get; set; }
 
             protected override async Task<HttpResponseMessage> SendAsync(
                 HttpRequestMessage request, CancellationToken cancellationToken) {
@@ -34,7 +35,7 @@ namespace GsPlugin.Tests {
                 if (request.Content != null) {
                     LastRequestBody = await request.Content.ReadAsStringAsync();
                 }
-                return new HttpResponseMessage(StatusCode) {
+                return ResponseFactory?.Invoke(CallCount) ?? new HttpResponseMessage(StatusCode) {
                     Content = new StringContent(ResponseBody, System.Text.Encoding.UTF8, "application/json")
                 };
             }
@@ -532,6 +533,225 @@ namespace GsPlugin.Tests {
         }
 
         // --- PostJsonAsync gzip behavior ---
+
+        [Fact]
+        public async Task FlushPendingScrobblesAsync_OpenCooldownPreservesAttempts() {
+            using (var temp = TempPluginDir.CreateWithDataManager("valid-token")) {
+                var pending = new PendingScrobble {
+                    Type = "start",
+                    StartData = new ScrobbleStartReq { game_id = "game-1", game_name = "Game" },
+                    FlushAttempts = 4
+                };
+                GsDataManager.EnqueuePendingScrobble(pending);
+                var breaker = new GsCircuitBreaker(failureThreshold: 1, timeout: TimeSpan.FromHours(1));
+                await breaker.ExecuteAsync(() => Task.FromResult(false), maxRetries: 0, isFailure: r => !r);
+                var handler = new MockHttpHandler();
+                var client = new GsApiClient(new HttpClient(handler), breaker);
+
+                await client.FlushPendingScrobblesAsync();
+
+                Assert.Equal(0, handler.CallCount);
+                Assert.Equal(4, Assert.Single(GsDataManager.PeekPendingScrobbles()).FlushAttempts);
+            }
+        }
+
+        [Fact]
+        public async Task FlushPendingScrobblesAsync_ExpiredOpenCircuitProbesWithoutOtherCalls() {
+            using (var temp = TempPluginDir.CreateWithDataManager("valid-token")) {
+                GsDataManager.EnqueuePendingScrobble(new PendingScrobble {
+                    Type = "start",
+                    StartData = new ScrobbleStartReq { game_id = "game-1", game_name = "Game" },
+                    FlushAttempts = 4
+                });
+                var breaker = new GsCircuitBreaker(failureThreshold: 1, timeout: TimeSpan.Zero);
+                await breaker.ExecuteAsync(() => Task.FromResult(false), maxRetries: 0, isFailure: r => !r);
+                Assert.Equal(GsCircuitBreaker.CircuitState.Open, breaker.State);
+                var handler = new MockHttpHandler { ResponseBody = "{\"status\":\"success\"}" };
+                var client = new GsApiClient(new HttpClient(handler), breaker);
+
+                await client.FlushPendingScrobblesAsync();
+
+                Assert.Equal(1, handler.CallCount);
+                Assert.Equal(GsCircuitBreaker.CircuitState.Closed, breaker.State);
+                Assert.Empty(GsDataManager.PeekPendingScrobbles());
+            }
+        }
+
+        [Fact]
+        public async Task FlushPendingScrobblesAsync_CircuitOpeningDoesNotBurnLaterItemAttempts() {
+            using (var temp = TempPluginDir.CreateWithDataManager("valid-token")) {
+                for (var i = 0; i < 2; i++) {
+                    GsDataManager.EnqueuePendingScrobble(new PendingScrobble {
+                        Type = "start",
+                        StartData = new ScrobbleStartReq { game_id = "game-" + i, game_name = "Game " + i }
+                    });
+                }
+                var breaker = new GsCircuitBreaker(failureThreshold: 1, timeout: TimeSpan.FromHours(1));
+                var handler = new MockHttpHandler { StatusCode = HttpStatusCode.ServiceUnavailable };
+                var client = new GsApiClient(new HttpClient(handler), breaker);
+
+                await client.FlushPendingScrobblesAsync();
+
+                var pending = GsDataManager.PeekPendingScrobbles();
+                Assert.Equal(1, handler.CallCount);
+                Assert.Equal(1, pending[0].FlushAttempts);
+                Assert.Equal(0, pending[1].FlushAttempts);
+            }
+        }
+
+        [Fact]
+        public async Task FlushPendingScrobblesAsync_FailedStartCannotBeOvertakenAndRecoveryPairsFinish() {
+            using (var temp = TempPluginDir.CreateWithDataManager("valid-token")) {
+                var sessionId = Guid.NewGuid().ToString();
+                GsDataManager.EnqueuePendingScrobble(new PendingScrobble {
+                    Type = "start",
+                    StartData = new ScrobbleStartReq { game_id = "game-1", plugin_id = "plugin-1", game_name = "Game" }
+                });
+                GsDataManager.EnqueuePendingScrobble(new PendingScrobble {
+                    Type = "finish",
+                    FinishData = new ScrobbleFinishReq { game_id = "game-1", plugin_id = "plugin-1", game_name = "Game" }
+                });
+                var handler = new MockHttpHandler {
+                    ResponseFactory = call => new HttpResponseMessage(HttpStatusCode.OK) {
+                        Content = new StringContent(call == 1
+                            ? "{\"status\":\"fail\",\"code\":\"TRY_LATER\"}"
+                            : call == 2
+                                ? "{\"status\":\"success\",\"data\":{\"session_id\":\"" + sessionId + "\"}}"
+                                : "{\"status\":\"success\",\"data\":{\"duration_seconds\":30}}",
+                            System.Text.Encoding.UTF8, "application/json")
+                    }
+                };
+                var client = new GsApiClient(new HttpClient(handler));
+
+                await client.FlushPendingScrobblesAsync();
+
+                var pending = GsDataManager.PeekPendingScrobbles();
+                Assert.Equal(1, handler.CallCount);
+                Assert.Equal(2, pending.Count);
+                Assert.Equal(1, pending[0].FlushAttempts);
+                Assert.Equal(0, pending[1].FlushAttempts);
+
+                await client.FlushPendingScrobblesAsync();
+
+                Assert.Equal(3, handler.CallCount);
+                Assert.Contains(sessionId, handler.LastRequestBody);
+                Assert.Empty(GsDataManager.PeekPendingScrobbles());
+            }
+        }
+
+        [Fact]
+        public async Task FlushPendingScrobblesAsync_TerminalStartFailureDropsDependentFinishTogether() {
+            using (var temp = TempPluginDir.CreateWithDataManager("valid-token")) {
+                GsDataManager.EnqueuePendingScrobble(new PendingScrobble {
+                    Type = "start",
+                    StartData = new ScrobbleStartReq { game_id = "game-1", plugin_id = "plugin-1", game_name = "Game" },
+                    FlushAttempts = 4
+                });
+                GsDataManager.EnqueuePendingScrobble(new PendingScrobble {
+                    Type = "finish",
+                    FinishData = new ScrobbleFinishReq { game_id = "game-1", plugin_id = "plugin-1", game_name = "Game" }
+                });
+                var nextStart = new PendingScrobble {
+                    Type = "start",
+                    StartData = new ScrobbleStartReq { game_id = "game-1", plugin_id = "plugin-1", game_name = "Game" }
+                };
+                GsDataManager.EnqueuePendingScrobble(nextStart);
+                var handler = new MockHttpHandler { ResponseBody = "{\"status\":\"fail\",\"code\":\"REJECTED\"}" };
+                var client = new GsApiClient(new HttpClient(handler));
+
+                await client.FlushPendingScrobblesAsync();
+
+                Assert.Equal(1, handler.CallCount);
+                Assert.Same(nextStart, Assert.Single(GsDataManager.PeekPendingScrobbles()));
+                Assert.Equal(0, nextStart.FlushAttempts);
+                Assert.Equal(2, GsDataManager.Data.DroppedScrobbleCount);
+            }
+        }
+
+        [Fact]
+        public async Task FlushPendingScrobblesAsync_RecoveredStartWithoutStopBecomesActiveSession() {
+            using (var temp = TempPluginDir.CreateWithDataManager("valid-token")) {
+                var sessionId = Guid.NewGuid().ToString();
+                GsDataManager.MutateAndSave(d => d.PendingStartGameIds.Add("game-1"));
+                GsDataManager.EnqueuePendingScrobble(new PendingScrobble {
+                    Type = "start",
+                    StartData = new ScrobbleStartReq { game_id = "game-1", plugin_id = "plugin-1", game_name = "Game" }
+                });
+                var handler = new MockHttpHandler {
+                    ResponseBody = "{\"status\":\"success\",\"data\":{\"session_id\":\"" + sessionId + "\"}}"
+                };
+                var client = new GsApiClient(new HttpClient(handler));
+
+                await client.FlushPendingScrobblesAsync();
+
+                Assert.Empty(GsDataManager.PeekPendingScrobbles());
+                Assert.Equal(sessionId, GsDataManager.Data.ActiveSessionsByGameId["game-1"]);
+                Assert.DoesNotContain("game-1", GsDataManager.Data.PendingStartGameIds);
+            }
+        }
+
+        [Theory]
+        [InlineData(408)]
+        [InlineData(429)]
+        [InlineData(500)]
+        [InlineData(503)]
+        public async Task V4TransientJsonResponse_RetriesAndReturnsRecovery(int status) {
+            using (var temp = TempPluginDir.CreateWithDataManager("valid-token")) {
+                var handler = new MockHttpHandler {
+                    ResponseFactory = call => new HttpResponseMessage(call == 1 ? (HttpStatusCode)status : HttpStatusCode.OK) {
+                        Content = new StringContent(call == 1
+                            ? "{\"success\":false,\"status\":\"force-full-sync\"}"
+                            : "{\"success\":true,\"sync_id\":\"recovered\"}", System.Text.Encoding.UTF8, "application/json")
+                    }
+                };
+                var breaker = new GsCircuitBreaker();
+                var client = new GsApiClient(new HttpClient(handler), breaker);
+
+                var result = await client.SyncLibraryFullBegin(new LibraryV4FullSyncBeginReq());
+
+                Assert.True(result.success);
+                Assert.Equal("recovered", result.sync_id);
+                Assert.Equal(2, handler.CallCount);
+                Assert.Equal(GsCircuitBreaker.CircuitState.Closed, breaker.State);
+            }
+        }
+
+        [Fact]
+        public async Task V4PermanentBusinessRejection_PreservesOutcomeWithoutRetryOrCircuitFailure() {
+            using (var temp = TempPluginDir.CreateWithDataManager("valid-token")) {
+                var handler = new MockHttpHandler {
+                    StatusCode = HttpStatusCode.BadRequest,
+                    ResponseBody = "{\"success\":false,\"status\":\"force-full-sync\",\"reason\":\"hash_mismatch\"}"
+                };
+                var breaker = new GsCircuitBreaker(failureThreshold: 1);
+                var client = new GsApiClient(new HttpClient(handler), breaker);
+
+                var result = await client.SyncLibraryFullCommit(new LibraryV4CommitReq());
+
+                Assert.False(result.success);
+                Assert.Equal("force-full-sync", result.status);
+                Assert.Equal(1, handler.CallCount);
+                Assert.Equal(GsCircuitBreaker.CircuitState.Closed, breaker.State);
+            }
+        }
+
+        [Fact]
+        public async Task V4RepeatedJsonServerErrors_OpenCircuit() {
+            using (var temp = TempPluginDir.CreateWithDataManager("valid-token")) {
+                var handler = new MockHttpHandler {
+                    StatusCode = HttpStatusCode.ServiceUnavailable,
+                    ResponseBody = "{\"success\":false}"
+                };
+                var breaker = new GsCircuitBreaker(failureThreshold: 3);
+                var client = new GsApiClient(new HttpClient(handler), breaker);
+
+                Assert.Null(await client.SyncLibraryFullBegin(new LibraryV4FullSyncBeginReq()));
+                Assert.Null(await client.SyncLibraryFullBegin(new LibraryV4FullSyncBeginReq()));
+
+                Assert.Equal(3, handler.CallCount);
+                Assert.Equal(GsCircuitBreaker.CircuitState.Open, breaker.State);
+            }
+        }
 
         [Fact]
         public async Task StartGameSession_AttachesInstallTokenHeader() {

--- a/GsPlugin.Tests/GsAssemblyIdentityTests.cs
+++ b/GsPlugin.Tests/GsAssemblyIdentityTests.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+using GsPlugin.Infrastructure;
+using Xunit;
+
+namespace GsPlugin.Tests {
+    public class GsAssemblyIdentityTests {
+        [Theory]
+        [InlineData(null, null, true)]
+        [InlineData(null, "null", true)]
+        [InlineData("null", null, true)]
+        [InlineData("null", "null", true)]
+        [InlineData(null, "b03f5f7f11d50a3a", false)]
+        [InlineData("null", "b03f5f7f11d50a3a", false)]
+        [InlineData("b03f5f7f11d50a3a", null, false)]
+        [InlineData("b03f5f7f11d50a3a", "null", false)]
+        [InlineData("b03f5f7f11d50a3a", "b03f5f7f11d50a3a", true)]
+        [InlineData("b03f5f7f11d50a3a", "cc7b13ffcd2ddd51", false)]
+        public void PublicKeyTokensMatch_RequiresExactSigningIdentity(string requestedToken, string candidateToken, bool expected) {
+            var requested = new AssemblyName("Dependency" + (requestedToken == null ? "" : ", PublicKeyToken=" + requestedToken));
+            var candidate = new AssemblyName("Dependency" + (candidateToken == null ? "" : ", PublicKeyToken=" + candidateToken));
+            Assert.Equal(expected, GsAssemblyIdentity.PublicKeyTokensMatch(requested, candidate));
+        }
+    }
+}

--- a/GsPlugin.Tests/GsDataRecoveryTests.cs
+++ b/GsPlugin.Tests/GsDataRecoveryTests.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using Xunit;
+using GsPlugin.Api;
+using GsPlugin.Models;
+
+namespace GsPlugin.Tests {
+    [Collection("StaticManagerTests")]
+    public class GsDataRecoveryTests {
+        [Fact]
+        public void QueueSessionFinishes_RejectsSnapshotFromAnEarlierIdentity() {
+            using (var temp = TempPluginDir.CreateWithDataManagerAndHashIndex()) {
+                var originalId = GsDataManager.Data.InstallID;
+                var generation = GsDataManager.Data.IdentityGeneration;
+                var sessions = new Dictionary<string, string> { ["game"] = "old-session" };
+                var finishes = new List<PendingScrobble> {
+                    new PendingScrobble { Type = "finish", FinishData = new ScrobbleFinishReq { session_id = "old-session" } }
+                };
+                GsDataManager.RotateInstallId();
+                Assert.False(GsDataManager.QueueSessionFinishesAndClearActive(sessions, finishes, originalId, generation));
+                GsDataManager.Initialize(temp.Path, null);
+                Assert.Empty(GsDataManager.Data.PendingScrobbles);
+                Assert.Empty(GsDataManager.Data.ActiveSessionsByGameId);
+            }
+        }
+
+        private static string DataPath(TempPluginDir temp) => Path.Combine(temp.Path, "gs_data.json");
+
+        private static void AssertDataUnavailable() {
+            Assert.Null(GsDataManager.DataOrNull);
+            Assert.Throws<InvalidOperationException>(() => { var unused = GsDataManager.Data; });
+        }
+
+        [Theory]
+        [InlineData("{\"InstallID\":\"saved-install\",\"OptedOut\":true,")]
+        [InlineData("null")]
+        [InlineData("[]")]
+        public void Initialize_InvalidExistingJson_PreservesFileAndAllowsRepair(string invalidJson) {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var originalId = GsDataManager.Data.InstallID;
+                var generation = GsDataManager.Data.IdentityGeneration;
+                var path = DataPath(temp);
+                File.WriteAllText(path, invalidJson);
+                var originalBytes = File.ReadAllBytes(path);
+
+                Assert.Throws<JsonException>(() => GsDataManager.Initialize(temp.Path, null));
+                AssertDataUnavailable();
+                GsDataManager.Save();
+
+                Assert.Equal(originalBytes, File.ReadAllBytes(path));
+                Assert.False(File.Exists(path + ".tmp"));
+                File.WriteAllText(path, JsonSerializer.Serialize(new GsData {
+                    InstallID = originalId,
+                    IdentityGeneration = generation,
+                    OptedOut = true,
+                    LinkedUserId = "synthetic-saved-user"
+                }));
+
+                GsDataManager.Initialize(temp.Path, null);
+
+                Assert.Equal(originalId, GsDataManager.Data.InstallID);
+                Assert.Equal(generation, GsDataManager.Data.IdentityGeneration);
+                Assert.True(GsDataManager.IsOptedOut);
+                Assert.Equal("synthetic-saved-user", GsDataManager.Data.LinkedUserId);
+            }
+        }
+
+        [Fact]
+        public void Initialize_ReadLockedExistingFile_DoesNotReplaceIdentityOrConsent() {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                GsDataManager.MutateAndSave(d => {
+                    d.OptedOut = true;
+                    d.InstallToken = "synthetic-saved-token";
+                    d.PendingStartGameIds.Add("saved-game");
+                });
+                var originalId = GsDataManager.Data.InstallID;
+                var path = DataPath(temp);
+                var originalBytes = File.ReadAllBytes(path);
+
+                using (new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None)) {
+                    Assert.Throws<IOException>(() => GsDataManager.Initialize(temp.Path, null));
+                    AssertDataUnavailable();
+                    GsDataManager.Save();
+                    Assert.False(File.Exists(path + ".tmp"));
+                }
+
+                Assert.Equal(originalBytes, File.ReadAllBytes(path));
+                GsDataManager.Initialize(temp.Path, null);
+                Assert.Equal(originalId, GsDataManager.Data.InstallID);
+                Assert.True(GsDataManager.IsOptedOut);
+                Assert.Equal("synthetic-saved-token", GsDataManager.Data.InstallToken);
+                Assert.Contains("saved-game", GsDataManager.Data.PendingStartGameIds);
+            }
+        }
+
+        [Fact]
+        public void Initialize_MissingDirectory_CreatesOneDurableIdentity() {
+            using (var temp = TempPluginDir.Create()) {
+                var freshDirectory = Path.Combine(temp.Path, "fresh-install");
+                GsDataManager.Initialize(freshDirectory, null);
+                var installId = GsDataManager.Data.InstallID;
+                var generation = GsDataManager.Data.IdentityGeneration;
+
+                Assert.True(Guid.TryParse(installId, out _));
+                Assert.Equal(1, generation);
+                Assert.False(GsDataManager.IsOptedOut);
+                Assert.True(File.Exists(Path.Combine(freshDirectory, "gs_data.json")));
+
+                GsDataManager.Initialize(freshDirectory, null);
+                Assert.Equal(installId, GsDataManager.Data.InstallID);
+                Assert.Equal(generation, GsDataManager.Data.IdentityGeneration);
+            }
+        }
+
+        [Theory]
+        [InlineData("install")]
+        [InlineData("generation")]
+        [InlineData("opt-out")]
+        public void TryMutateIfActiveIdentity_RejectsStaleOrOptedOutResponses(string changedField) {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var installId = GsDataManager.Data.InstallID;
+                var generation = GsDataManager.Data.IdentityGeneration;
+                GsDataManager.MutateAndSave(d => {
+                    if (changedField == "install") d.InstallID = Guid.NewGuid().ToString();
+                    if (changedField == "generation") d.IdentityGeneration++;
+                    if (changedField == "opt-out") d.OptedOut = true;
+                });
+                var originalBytes = File.ReadAllBytes(DataPath(temp));
+                var invoked = false;
+
+                Assert.False(GsDataManager.TryMutateIfActiveIdentity(installId, generation, d => {
+                    invoked = true;
+                    d.LinkedUserId = "stale-response-user";
+                }));
+
+                Assert.False(invoked);
+                Assert.Null(GsDataManager.Data.LinkedUserId);
+                Assert.Equal(originalBytes, File.ReadAllBytes(DataPath(temp)));
+            }
+        }
+
+        [Fact]
+        public void TryMutateIfActiveIdentity_OptingBackInDoesNotReviveAnOldResponse() {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var installId = GsDataManager.Data.InstallID;
+                var generation = GsDataManager.Data.IdentityGeneration;
+                GsDataManager.PerformOptOut();
+                GsDataManager.PerformOptIn();
+
+                Assert.False(GsDataManager.TryMutateIfActiveIdentity(installId, generation,
+                    d => d.LinkedUserId = "stale-response-user"));
+                Assert.True(GsDataManager.TryMutateIfActiveIdentity(installId, GsDataManager.Data.IdentityGeneration,
+                    d => d.LinkedUserId = "current-response-user"));
+
+                GsDataManager.Initialize(temp.Path, null);
+                Assert.Equal("current-response-user", GsDataManager.Data.LinkedUserId);
+            }
+        }
+
+        [Fact]
+        public void QueueSessionFinishes_WriteFailureRestoresCollectionsAndCanBeRetried() {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var existing = new PendingScrobble { Type = "start", StartData = new ScrobbleStartReq { game_id = "other-game" } };
+                GsDataManager.MutateAndSave(d => {
+                    d.PendingScrobbles.Add(existing);
+                    d.ActiveSessionsByGameId["stopped-game"] = "session-to-finish";
+                });
+                var previousQueue = GsDataManager.Data.PendingScrobbles;
+                var previousSessions = GsDataManager.Data.ActiveSessionsByGameId;
+                var sessions = GsDataManager.SnapshotActiveSessions();
+                var finish = new PendingScrobble {
+                    Type = "finish",
+                    FinishData = new ScrobbleFinishReq { game_id = "stopped-game", session_id = "session-to-finish" }
+                };
+                var finishes = new List<PendingScrobble> { finish };
+                var path = DataPath(temp);
+                var originalBytes = File.ReadAllBytes(path);
+
+                // Read sharing allows inspection but prevents File.Replace from deleting
+                // the destination, exercising the real atomic writer's failure path.
+                using (new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read)) {
+                    Assert.False(GsDataManager.QueueSessionFinishesAndClearActive(sessions, finishes));
+                    Assert.Same(previousQueue, GsDataManager.Data.PendingScrobbles);
+                    Assert.Same(previousSessions, GsDataManager.Data.ActiveSessionsByGameId);
+                    Assert.Same(existing, Assert.Single(GsDataManager.PeekPendingScrobbles()));
+                    Assert.Equal("session-to-finish", GsDataManager.Data.ActiveSessionsByGameId["stopped-game"]);
+                    Assert.Equal(originalBytes, File.ReadAllBytes(path));
+                }
+
+                Assert.True(GsDataManager.QueueSessionFinishesAndClearActive(sessions, finishes));
+                GsDataManager.Initialize(temp.Path, null);
+                Assert.Equal(2, GsDataManager.Data.PendingScrobbles.Count);
+                Assert.Equal("session-to-finish", GsDataManager.Data.PendingScrobbles[1].FinishData.session_id);
+                Assert.Empty(GsDataManager.Data.ActiveSessionsByGameId);
+            }
+        }
+
+        [Fact]
+        public void QueueSessionFinishes_ResolvesStartThatCompletedAfterShutdownSnapshot() {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var start = new PendingScrobble {
+                    Type = "start",
+                    StartData = new ScrobbleStartReq { game_id = "starting-game", plugin_id = "source" }
+                };
+                GsDataManager.MutateAndSave(d => {
+                    d.PendingScrobbles.Add(start);
+                    d.PendingStartGameIds.Add("starting-game");
+                });
+                var snapshot = GsDataManager.SnapshotActiveSessions();
+                var finish = new PendingScrobble {
+                    Type = "finish",
+                    FinishData = new ScrobbleFinishReq { game_id = "starting-game", plugin_id = "source" }
+                };
+                Assert.True(GsDataManager.CompletePendingStart(start, "late-session"));
+
+                Assert.True(GsDataManager.QueueSessionFinishesAndClearActive(snapshot, new List<PendingScrobble> { finish }));
+                GsDataManager.Initialize(temp.Path, null);
+                Assert.Equal("late-session", Assert.Single(GsDataManager.PeekPendingScrobbles()).FinishData.session_id);
+                Assert.Empty(GsDataManager.SnapshotActiveSessions());
+                Assert.False(GsDataManager.HasPendingStart("starting-game"));
+            }
+        }
+
+        [Fact]
+        public void QueueSessionFinishes_DoesNotClearANewerSessionForTheSameGame() {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                GsDataManager.MutateAndSave(d => {
+                    d.ActiveSessionsByGameId["restarted-game"] = "new-session";
+                    d.ActiveSessionsByGameId["stopped-game"] = "matching-session";
+                });
+                var snapshot = new Dictionary<string, string> {
+                    { "restarted-game", "old-session" }, { "stopped-game", "matching-session" }
+                };
+                var finishes = new List<PendingScrobble> {
+                    new PendingScrobble { Type = "finish", FinishData = new ScrobbleFinishReq { game_id = "restarted-game", session_id = "old-session" } },
+                    new PendingScrobble { Type = "finish", FinishData = new ScrobbleFinishReq { game_id = "stopped-game", session_id = "matching-session" } }
+                };
+
+                Assert.True(GsDataManager.QueueSessionFinishesAndClearActive(snapshot, finishes));
+                GsDataManager.Initialize(temp.Path, null);
+
+                Assert.Equal("new-session", GsDataManager.Data.ActiveSessionsByGameId["restarted-game"]);
+                Assert.False(GsDataManager.Data.ActiveSessionsByGameId.ContainsKey("stopped-game"));
+                Assert.Equal(2, GsDataManager.Data.PendingScrobbles.Count);
+            }
+        }
+    }
+}

--- a/GsPlugin.Tests/GsPendingScrobbleStateTests.cs
+++ b/GsPlugin.Tests/GsPendingScrobbleStateTests.cs
@@ -1,0 +1,298 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+using GsPlugin.Api;
+using GsPlugin.Models;
+
+namespace GsPlugin.Tests {
+    [Collection("StaticManagerTests")]
+    public class GsPendingScrobbleStateTests {
+        private static PendingScrobble Start(string game = "game-a", string plugin = "plugin-a") => new PendingScrobble {
+            Type = "start",
+            StartData = new ScrobbleStartReq { game_id = game, plugin_id = plugin },
+            QueuedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        private static PendingScrobble Finish(string game = "game-a", string plugin = "plugin-a", string session = null) => new PendingScrobble {
+            Type = "finish",
+            FinishData = new ScrobbleFinishReq { game_id = game, plugin_id = plugin, session_id = session },
+            QueuedAt = new DateTime(2026, 1, 1, 0, 1, 0, DateTimeKind.Utc)
+        };
+
+        private static void Queue(params PendingScrobble[] items) {
+            GsDataManager.MutateAndSave(d => {
+                d.PendingScrobbles.AddRange(items);
+                foreach (var item in items.Where(p => p.Type == "start")) {
+                    if (!d.PendingStartGameIds.Contains(item.StartData.game_id)) {
+                        d.PendingStartGameIds.Add(item.StartData.game_id);
+                    }
+                }
+            });
+        }
+
+        [Fact]
+        public void CompletePendingStart_PairsOnlyItsGameAndPluginAcrossInterleavedEvents() {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var start = Start();
+                var unrelatedGame = Finish("game-b");
+                var unrelatedPluginStart = Start(plugin: "plugin-b");
+                var unrelatedPluginFinish = Finish(plugin: "plugin-b");
+                var matchingFinish = Finish();
+                Queue(start, unrelatedGame, unrelatedPluginStart, unrelatedPluginFinish, matchingFinish);
+
+                Assert.True(GsDataManager.CompletePendingStart(start, "replayed-session"));
+
+                Assert.Equal("replayed-session", matchingFinish.FinishData.session_id);
+                Assert.Null(unrelatedGame.FinishData.session_id);
+                Assert.Null(unrelatedPluginFinish.FinishData.session_id);
+                Assert.DoesNotContain(start, GsDataManager.Data.PendingScrobbles);
+                Assert.Empty(GsDataManager.Data.ActiveSessionsByGameId);
+                GsDataManager.Initialize(temp.Path, null);
+                Assert.Equal("replayed-session", GsDataManager.Data.PendingScrobbles.Last().FinishData.session_id);
+                Assert.Equal(4, GsDataManager.Data.PendingScrobbles.Count);
+            }
+        }
+
+        [Fact]
+        public void CompletePendingStart_NeverPairsAcrossTheNextLaunch() {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var firstStart = Start();
+                var secondStart = Start();
+                var secondFinish = Finish();
+                Queue(firstStart, secondStart, secondFinish);
+
+                Assert.True(GsDataManager.CompletePendingStart(firstStart, "first-session"));
+                Assert.Null(secondFinish.FinishData.session_id);
+                Assert.True(GsDataManager.HasPendingStart("game-a"));
+                Assert.False(GsDataManager.HasActiveSession("game-a"));
+
+                Assert.True(GsDataManager.CompletePendingStart(secondStart, "second-session"));
+                Assert.Equal("second-session", secondFinish.FinishData.session_id);
+                Assert.False(GsDataManager.HasPendingStart("game-a"));
+                GsDataManager.Initialize(temp.Path, null);
+                Assert.Equal("second-session", Assert.Single(GsDataManager.PeekPendingScrobbles()).FinishData.session_id);
+            }
+        }
+
+        [Fact]
+        public void CompletePendingStart_PersistsSessionForAStopThatHasNotArrivedYet() {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var start = Start();
+                Queue(start);
+
+                Assert.True(GsDataManager.CompletePendingStart(start, "active-session"));
+                GsDataManager.Initialize(temp.Path, null);
+
+                Assert.Equal("active-session", GsDataManager.Data.ActiveSessionsByGameId["game-a"]);
+                Assert.False(GsDataManager.HasPendingStart("game-a"));
+                Assert.Empty(GsDataManager.PeekPendingScrobbles());
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void CompletePendingStart_AcceptedQueuedResponseSupportsMissingSessionId(bool hasQueuedFinish) {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var start = Start();
+                if (hasQueuedFinish) Queue(start, Finish());
+                else Queue(start);
+
+                Assert.True(GsDataManager.CompletePendingStart(start, null));
+                GsDataManager.Initialize(temp.Path, null);
+
+                Assert.False(GsDataManager.HasActiveSession("game-a"));
+                Assert.Equal(!hasQueuedFinish, GsDataManager.HasPendingStart("game-a"));
+                if (hasQueuedFinish) {
+                    var finish = Assert.Single(GsDataManager.PeekPendingScrobbles());
+                    Assert.Equal("finish", finish.Type);
+                    Assert.Null(finish.FinishData.session_id);
+                }
+                else {
+                    Assert.Empty(GsDataManager.PeekPendingScrobbles());
+                }
+            }
+        }
+
+        [Fact]
+        public void CompletePendingStart_DoesNotOverwriteAnAlreadyBoundFinish() {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var start = Start();
+                var finish = Finish(session: "already-bound-session");
+                Queue(start, finish);
+
+                Assert.True(GsDataManager.CompletePendingStart(start, "new-response-session"));
+                GsDataManager.Initialize(temp.Path, null);
+
+                Assert.Equal("already-bound-session", Assert.Single(GsDataManager.PeekPendingScrobbles()).FinishData.session_id);
+            }
+        }
+
+        [Theory]
+        [InlineData("finished-session", false)]
+        [InlineData("newer-session", true)]
+        public void CompletePendingScrobble_ClearsOnlyTheMatchingActiveSession(string activeSession, bool remainsActive) {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var finish = Finish(session: "finished-session");
+                Queue(finish);
+                GsDataManager.MutateAndSave(d => d.ActiveSessionsByGameId["game-a"] = activeSession);
+
+                Assert.True(GsDataManager.CompletePendingScrobble(finish));
+                GsDataManager.Initialize(temp.Path, null);
+
+                Assert.Empty(GsDataManager.PeekPendingScrobbles());
+                Assert.Equal(remainsActive, GsDataManager.HasActiveSession("game-a"));
+                if (remainsActive) Assert.Equal(activeSession, GsDataManager.Data.ActiveSessionsByGameId["game-a"]);
+            }
+        }
+
+        [Fact]
+        public void DropPendingScrobble_DropsOnlyTheRejectedLaunchAndItsFinish() {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var firstStart = Start();
+                var firstFinish = Finish();
+                var nextStart = Start();
+                var nextFinish = Finish();
+                var unrelatedFinish = Finish("game-b", session: "unrelated-session");
+                Queue(firstStart, unrelatedFinish, firstFinish, nextStart, nextFinish);
+
+                Assert.True(GsDataManager.DropPendingScrobble(firstStart));
+
+                Assert.Equal(new[] { unrelatedFinish, nextStart, nextFinish }, GsDataManager.PeekPendingScrobbles());
+                Assert.Equal(2, GsDataManager.Data.DroppedScrobbleCount);
+                Assert.True(GsDataManager.HasPendingStart("game-a"));
+                Assert.True(GsDataManager.DropPendingScrobble(nextStart));
+                Assert.False(GsDataManager.HasPendingStart("game-a"));
+                GsDataManager.Initialize(temp.Path, null);
+
+                Assert.Equal("unrelated-session", Assert.Single(GsDataManager.PeekPendingScrobbles()).FinishData.session_id);
+                Assert.Equal(4, GsDataManager.Data.DroppedScrobbleCount);
+            }
+        }
+
+        [Fact]
+        public void PeekPendingScrobbles_StopsAtClaimedWorkAndClaimsDoNotSurviveRestart() {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var beforeClaim = Finish("game-b", session: "earlier-session");
+                var claimedStart = Start();
+                var laterFinish = Finish();
+                Queue(beforeClaim, claimedStart, laterFinish);
+                GsDataManager.ClaimPendingScrobble(claimedStart);
+
+                Assert.Same(beforeClaim, Assert.Single(GsDataManager.PeekPendingScrobbles()));
+                GsDataManager.ReleasePendingScrobble(claimedStart);
+                Assert.Equal(new[] { beforeClaim, claimedStart, laterFinish }, GsDataManager.PeekPendingScrobbles());
+                GsDataManager.ClaimPendingScrobble(claimedStart);
+                GsDataManager.Save();
+
+                GsDataManager.Initialize(temp.Path, null);
+
+                Assert.Equal(3, GsDataManager.PeekPendingScrobbles().Count);
+                Assert.Equal("start", GsDataManager.PeekPendingScrobbles()[1].Type);
+            }
+        }
+
+        [Fact]
+        public void HasEarlierPendingScrobble_OrdersOnlyTheSameGameAndPlugin() {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var otherGame = Start("game-b");
+                var otherPlugin = Start(plugin: "plugin-b");
+                var start = Start();
+                var finish = Finish();
+                Queue(otherGame, otherPlugin, start, finish);
+
+                Assert.False(GsDataManager.HasEarlierPendingScrobble(start));
+                Assert.True(GsDataManager.HasEarlierPendingScrobble(finish));
+                Assert.True(GsDataManager.CompletePendingStart(start, "paired-session"));
+                Assert.False(GsDataManager.HasEarlierPendingScrobble(finish));
+            }
+        }
+
+        [Fact]
+        public void CompletionAfterOptOutAndOptInCannotRestoreOldQueueOrSessions() {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var start = Start();
+                var finish = Finish();
+                Queue(start, finish);
+                GsDataManager.PerformOptOut();
+                Assert.False(GsDataManager.CompletePendingStart(start, "stale-session"));
+                Assert.False(GsDataManager.CompletePendingScrobble(finish));
+                Assert.False(GsDataManager.DropPendingScrobble(start));
+                GsDataManager.PerformOptIn();
+
+                Assert.False(GsDataManager.CompletePendingStart(start, "stale-session"));
+                Assert.False(GsDataManager.CompletePendingScrobble(finish));
+                Assert.False(GsDataManager.DropPendingScrobble(start));
+                GsDataManager.Initialize(temp.Path, null);
+
+                Assert.Empty(GsDataManager.PeekPendingScrobbles());
+                Assert.Empty(GsDataManager.Data.ActiveSessionsByGameId);
+                Assert.Empty(GsDataManager.Data.PendingStartGameIds);
+                Assert.Equal(0, GsDataManager.Data.DroppedScrobbleCount);
+            }
+        }
+
+        [Theory]
+        [InlineData("start")]
+        [InlineData("finish")]
+        [InlineData("drop")]
+        public void CompletionWriteFailure_RestoresPairingClaimsAndCollectionsWithoutNotifying(string operation) {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var start = Start();
+                var finish = Finish(session: operation == "finish" ? "completed-session" : null);
+                if (operation == "finish") Queue(finish);
+                else Queue(start, finish);
+                GsDataManager.MutateAndSave(d => d.ActiveSessionsByGameId["game-a"] = "completed-session");
+                var target = operation == "finish" ? finish : start;
+                GsDataManager.ClaimPendingScrobble(target);
+                var before = GsDataManager.Data;
+                var previousQueue = before.PendingScrobbles;
+                var previousSessions = before.ActiveSessionsByGameId;
+                var previousMarkers = before.PendingStartGameIds;
+                var originalFinishSession = finish.FinishData.session_id;
+                var path = Path.Combine(temp.Path, "gs_data.json");
+                var originalBytes = File.ReadAllBytes(path);
+                Func<bool> complete = () => operation == "start"
+                    ? GsDataManager.CompletePendingStart(start, "replayed-session")
+                    : operation == "finish"
+                        ? GsDataManager.CompletePendingScrobble(finish)
+                        : GsDataManager.DropPendingScrobble(start);
+                var notifications = 0;
+                EventHandler handler = (sender, args) => notifications++;
+                GsDataManager.DiagnosticsStateChanged += handler;
+                try {
+                    using (new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read)) {
+                        Assert.False(complete());
+
+                        Assert.Same(before, GsDataManager.Data);
+                        Assert.Same(previousQueue, GsDataManager.Data.PendingScrobbles);
+                        Assert.Same(previousSessions, GsDataManager.Data.ActiveSessionsByGameId);
+                        Assert.Same(previousMarkers, GsDataManager.Data.PendingStartGameIds);
+                        Assert.Equal(originalFinishSession, finish.FinishData.session_id);
+                        Assert.Equal("completed-session", GsDataManager.Data.ActiveSessionsByGameId["game-a"]);
+                        Assert.Empty(GsDataManager.PeekPendingScrobbles());
+                        Assert.Equal(0, GsDataManager.Data.DroppedScrobbleCount);
+                        Assert.Equal(0, notifications);
+                        Assert.Equal(originalBytes, File.ReadAllBytes(path));
+                    }
+
+                    Assert.True(complete());
+                    Assert.Equal(1, notifications);
+                    GsDataManager.Initialize(temp.Path, null);
+                    if (operation == "start") {
+                        Assert.Equal("replayed-session", Assert.Single(GsDataManager.PeekPendingScrobbles()).FinishData.session_id);
+                    }
+                    else {
+                        Assert.Empty(GsDataManager.PeekPendingScrobbles());
+                    }
+                    Assert.Equal(operation == "drop" ? 2 : 0, GsDataManager.Data.DroppedScrobbleCount);
+                }
+                finally {
+                    GsDataManager.DiagnosticsStateChanged -= handler;
+                    GsDataManager.ReleasePendingScrobble(target);
+                }
+            }
+        }
+    }
+}

--- a/GsPlugin.Tests/GsPlugin.Tests.csproj
+++ b/GsPlugin.Tests/GsPlugin.Tests.csproj
@@ -19,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="PlayniteSDK" Version="6.15.0" />
+    <PackageReference Include="Sentry" Version="6.1.0" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119.0" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="System.Text.Json" Version="9.0.9" />

--- a/GsPlugin.Tests/GsScrobblingServiceReliabilityTests.cs
+++ b/GsPlugin.Tests/GsScrobblingServiceReliabilityTests.cs
@@ -1,0 +1,304 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using GsPlugin.Api;
+using GsPlugin.Models;
+using GsPlugin.Services;
+using Playnite.SDK.Events;
+using Playnite.SDK.Models;
+using Xunit;
+
+namespace GsPlugin.Tests {
+    [Collection("StaticManagerTests")]
+    public class GsScrobblingServiceReliabilityTests {
+        private static Game Game() => new Game {
+            Id = Guid.NewGuid(),
+            Name = "Test Game",
+            GameId = "123",
+            PluginId = Guid.Parse("CB91DFC9-B977-43BF-8E70-55F46E410FAB")
+        };
+
+        private static T Event<T>(Game game) where T : new() {
+            var result = new T();
+            typeof(T).GetProperty("Game").SetValue(result, game);
+            return result;
+        }
+
+        private static GsData ReloadSaved(TempPluginDir temp) =>
+            JsonSerializer.Deserialize<GsData>(File.ReadAllText(Path.Combine(temp.Path, "gs_data.json")));
+
+        private static GsScrobblingService Service(FakeApi api, Provider provider = null) =>
+            new GsScrobblingService(api, provider ?? new Provider(), null) {
+                QueueStatusPollInterval = TimeSpan.Zero,
+                QueueStatusPollBudget = TimeSpan.Zero
+            };
+
+        [Fact]
+        public async Task StopWhileStartPending_PersistsBothEventsAndCompletesMatchingSession() {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var response = new TaskCompletionSource<ScrobbleStartRes>();
+                var api = new FakeApi { OnStart = _ => response.Task };
+                var service = Service(api);
+                var game = Game();
+                var start = service.OnGameStartAsync(Event<OnGameStartingEventArgs>(game));
+                var stop = service.OnGameStoppedAsync(Event<OnGameStoppedEventArgs>(game));
+                Assert.False(stop.IsCompleted);
+                Assert.Empty(api.Finishes);
+                Assert.Equal(new[] { "start", "finish" }, ReloadSaved(temp).PendingScrobbles.Select(p => p.Type));
+                Assert.Empty(GsDataManager.PeekPendingScrobbles()); // Live handlers own their claims.
+
+                response.SetResult(new ScrobbleStartRes { session_id = "session-1" });
+                await Task.WhenAll(start, stop);
+                Assert.Equal("session-1", Assert.Single(api.Finishes).session_id);
+                Assert.Empty(ReloadSaved(temp).PendingScrobbles);
+                Assert.Empty(GsDataManager.SnapshotActiveSessions());
+            }
+        }
+
+        [Fact]
+        public async Task RestartWhilePreviousFinishPending_PreservesNewActiveSession() {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var response = new TaskCompletionSource<ScrobbleFinishRes>();
+                var number = 0;
+                var api = new FakeApi {
+                    OnStart = _ => Task.FromResult(new ScrobbleStartRes { session_id = "session-" + (++number) }),
+                    OnFinish = _ => response.Task
+                };
+                var service = Service(api);
+                var game = Game();
+                await service.OnGameStartAsync(Event<OnGameStartingEventArgs>(game));
+                var stop = service.OnGameStoppedAsync(Event<OnGameStoppedEventArgs>(game));
+                var restart = service.OnGameStartAsync(Event<OnGameStartingEventArgs>(game));
+                Assert.False(restart.IsCompleted);
+                response.SetResult(new ScrobbleFinishRes());
+                await Task.WhenAll(stop, restart);
+                Assert.True(GsDataManager.TryGetActiveSession(game.Id.ToString(), out var active));
+                Assert.Equal("session-2", active);
+                Assert.Equal("session-1", Assert.Single(api.Finishes).session_id);
+            }
+        }
+
+        [Fact]
+        public async Task FailedStartAndStop_RemainInOrderWithoutSendingFinishEarly() {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var api = new FakeApi { OnStart = _ => Task.FromResult<ScrobbleStartRes>(null) };
+                var service = Service(api);
+                var game = Game();
+                await service.OnGameStartAsync(Event<OnGameStartingEventArgs>(game));
+                await service.OnGameStoppedAsync(Event<OnGameStoppedEventArgs>(game));
+                Assert.Empty(api.Finishes);
+                var pending = ReloadSaved(temp).PendingScrobbles;
+                Assert.Equal(new[] { "start", "finish" }, pending.Select(p => p.Type));
+                Assert.Null(pending[1].FinishData.session_id);
+            }
+        }
+
+        [Fact]
+        public async Task Shutdown_PersistsEveryFinishBeforeAwaitingFirstResponse() {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                GsDataManager.MutateAndSave(d => {
+                    d.ActiveSessionsByGameId["game-a"] = "session-a";
+                    d.ActiveSessionsByGameId["game-b"] = "session-b";
+                });
+                var response = new TaskCompletionSource<ScrobbleFinishRes>();
+                var api = new FakeApi { OnFinish = _ => response.Task };
+                var stopping = Service(api).OnApplicationStoppedAsync();
+                Assert.False(stopping.IsCompleted);
+                Assert.Single(api.Finishes);
+                var saved = ReloadSaved(temp);
+                Assert.Equal(2, saved.PendingScrobbles.Count);
+                Assert.Empty(saved.ActiveSessionsByGameId);
+                Assert.Single(saved.PendingScrobbles.Select(p => p.FinishData.finished_at).Distinct());
+                response.SetResult(new ScrobbleFinishRes());
+                await stopping;
+                Assert.Empty(ReloadSaved(temp).PendingScrobbles);
+            }
+        }
+
+        [Fact]
+        public async Task ShutdownDuringPendingStart_PersistsPairedFinishForReplay() {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var response = new TaskCompletionSource<ScrobbleStartRes>();
+                var api = new FakeApi { OnStart = _ => response.Task };
+                var service = Service(api);
+                var start = service.OnGameStartAsync(Event<OnGameStartingEventArgs>(Game()));
+                await service.OnApplicationStoppedAsync();
+                Assert.Equal(new[] { "start", "finish" }, ReloadSaved(temp).PendingScrobbles.Select(p => p.Type));
+                Assert.Empty(GsDataManager.PeekPendingScrobbles()); // Finish cannot overtake claimed start.
+                response.SetResult(new ScrobbleStartRes { session_id = "shutdown-session" });
+                await start;
+                var finish = Assert.Single(GsDataManager.PeekPendingScrobbles());
+                Assert.Equal("shutdown-session", finish.FinishData.session_id);
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task FailedAchievementRead_PreservesBaselineWithoutUploading(bool full) {
+            using (var temp = TempPluginDir.CreateWithDataManagerAndHashIndex()) {
+                var game = Game();
+                GsSyncHashIndex.ReplaceAchievementIndex(new Dictionary<string, string> { [game.Id.ToString()] = "old-item" });
+                GsDataManager.MutateAndSave(d => d.LastAchievementHash = "old-global");
+                var api = new FakeApi();
+                var provider = new Provider { Result = AchievementReadResult.Unavailable("unreadable") };
+                var service = Service(api, provider);
+                var result = full
+                    ? await service.SyncAchievementsFullAsync(new[] { game })
+                    : await service.SyncAchievementsDiffAsync(new[] { game });
+                Assert.Equal(SyncLibraryResult.Error, result);
+                Assert.Equal(0, api.AchievementUploads);
+                Assert.Equal("old-global", GsDataManager.Data.LastAchievementHash);
+                Assert.Equal("old-item", GsSyncHashIndex.GetAchievementFingerprints()[game.Id.ToString()]);
+            }
+        }
+
+        [Fact]
+        public async Task ConfirmedEmptyAchievementRead_ClearsOnlyAfterCompletedServerJob() {
+            using (var temp = TempPluginDir.CreateWithDataManagerAndHashIndex()) {
+                var game = Game();
+                GsSyncHashIndex.ReplaceAchievementIndex(new Dictionary<string, string> { [game.Id.ToString()] = "old-item" });
+                GsDataManager.MutateAndSave(d => d.LastAchievementHash = "old-global");
+                var api = new FakeApi();
+                var result = await Service(api).SyncAchievementsDiffAsync(new[] { game });
+                Assert.Equal(SyncLibraryResult.Success, result);
+                Assert.Empty(Assert.Single(api.AchievementDiff.changed).achievements);
+                Assert.Equal(0, GsSyncHashIndex.AchievementEntryCount);
+            }
+        }
+
+        [Theory]
+        [InlineData("library-full", "processing")]
+        [InlineData("library-diff", "processing")]
+        [InlineData("achievement-full", "processing")]
+        [InlineData("achievement-diff", "processing")]
+        [InlineData("library-full", "failed")]
+        [InlineData("achievement-diff", "partial")]
+        public async Task UnconfirmedQueueJob_DoesNotCommitEitherBaseline(string path, string status) {
+            using (var temp = TempPluginDir.CreateWithDataManagerAndHashIndex()) {
+                var game = Game();
+                var id = game.Id.ToString();
+                GsSyncHashIndex.ReplaceLibraryIndex(new Dictionary<string, string> { [id] = "old-library" });
+                GsSyncHashIndex.ReplaceAchievementIndex(new Dictionary<string, string> { [id] = "old-achievement" });
+                GsDataManager.MutateAndSave(d => { d.LastLibraryHash = "old-library-global"; d.LastAchievementHash = "old-achievement-global"; });
+                var api = new FakeApi { QueueStatus = status };
+                var provider = new Provider { Result = AchievementReadResult.Available(new List<AchievementItem> { new AchievementItem { Name = "new" } }) };
+                var service = Service(api, provider);
+                SyncLibraryResult result;
+                switch (path) {
+                    case "library-full": result = await service.SyncLibraryFullAsync(new[] { game }); break;
+                    case "library-diff": result = await service.SyncLibraryDiffAsync(new[] { game }); break;
+                    case "achievement-full": result = await service.SyncAchievementsFullAsync(new[] { game }); break;
+                    default: result = await service.SyncAchievementsDiffAsync(new[] { game }); break;
+                }
+                Assert.Equal(SyncLibraryResult.Error, result);
+                Assert.Equal("old-library-global", GsDataManager.Data.LastLibraryHash);
+                Assert.Equal("old-achievement-global", GsDataManager.Data.LastAchievementHash);
+                Assert.Equal("old-library", GsSyncHashIndex.GetLibraryFingerprints()[id]);
+                Assert.Equal("old-achievement", GsSyncHashIndex.GetAchievementFingerprints()[id]);
+            }
+        }
+
+        [Fact]
+        public async Task MissingQueueId_DoesNotCommitBaseline() {
+            using (var temp = TempPluginDir.CreateWithDataManagerAndHashIndex()) {
+                var api = new FakeApi { QueueId = null };
+                var result = await Service(api).SyncLibraryFullAsync(new[] { Game() });
+                Assert.Equal(SyncLibraryResult.Error, result);
+                Assert.Null(GsDataManager.Data.LastLibraryHash);
+                Assert.False(GsSyncHashIndex.HasLibraryBaseline);
+            }
+        }
+
+        [Theory]
+        [InlineData("library-full")]
+        [InlineData("library-diff")]
+        [InlineData("achievement-full")]
+        [InlineData("achievement-diff")]
+        public async Task OptOutDuringQueuePoll_RejectsOldIdentityBaseline(string path) {
+            using (var temp = TempPluginDir.CreateWithDataManagerAndHashIndex()) {
+                var game = Game();
+                var id = game.Id.ToString();
+                GsSyncHashIndex.ReplaceLibraryIndex(new Dictionary<string, string> { [id] = "old-library" });
+                GsSyncHashIndex.ReplaceAchievementIndex(new Dictionary<string, string> { [id] = "old-achievement" });
+                GsDataManager.MutateAndSave(d => { d.LastLibraryHash = "old-library-global"; d.LastAchievementHash = "old-achievement-global"; });
+                var pollReached = new TaskCompletionSource<bool>();
+                var response = new TaskCompletionSource<QueueStatusRes>();
+                var api = new FakeApi {
+                    OnQueueStatus = () => { pollReached.TrySetResult(true); return response.Task; }
+                };
+                var provider = new Provider { Result = AchievementReadResult.Available(new List<AchievementItem> { new AchievementItem { Name = "new" } }) };
+                var service = Service(api, provider);
+                Task<SyncLibraryResult> sync;
+                switch (path) {
+                    case "library-full": sync = service.SyncLibraryFullAsync(new[] { game }); break;
+                    case "library-diff": sync = service.SyncLibraryDiffAsync(new[] { game }); break;
+                    case "achievement-full": sync = service.SyncAchievementsFullAsync(new[] { game }); break;
+                    default: sync = service.SyncAchievementsDiffAsync(new[] { game }); break;
+                }
+                await pollReached.Task;
+                GsDataManager.PerformOptOut();
+                var libraryAfterOptOut = GsSyncHashIndex.GetLibraryFingerprints();
+                var achievementsAfterOptOut = GsSyncHashIndex.GetAchievementFingerprints();
+                response.SetResult(new QueueStatusRes { success = true, data = new QueueStatusData { status = "completed" } });
+                Assert.Equal(SyncLibraryResult.Error, await sync);
+                Assert.Null(GsDataManager.Data.LastLibraryHash);
+                Assert.Null(GsDataManager.Data.LastAchievementHash);
+                Assert.Equal(libraryAfterOptOut, GsSyncHashIndex.GetLibraryFingerprints());
+                Assert.Equal(achievementsAfterOptOut, GsSyncHashIndex.GetAchievementFingerprints());
+            }
+        }
+
+        private sealed class Provider : IAchievementProvider, IReliableAchievementProvider {
+            public AchievementReadResult Result = AchievementReadResult.Available(null);
+            public bool IsInstalled => true;
+            public bool IsPluginLoaded => true;
+            public string ProviderName => "test";
+            public string GetVersion() => "1";
+            public (int unlocked, int total)? GetCounts(Guid gameId) => null;
+            public List<AchievementItem> GetAchievements(Guid gameId) => Result.IsAvailable ? Result.Achievements : null;
+            public AchievementReadResult ReadAchievements(Guid gameId) => Result;
+        }
+
+        private sealed class FakeApi : IGsApiClient {
+            public Func<ScrobbleStartReq, Task<ScrobbleStartRes>> OnStart = _ => Task.FromResult(new ScrobbleStartRes { session_id = "session" });
+            public Func<ScrobbleFinishReq, Task<ScrobbleFinishRes>> OnFinish = _ => Task.FromResult(new ScrobbleFinishRes());
+            public List<ScrobbleFinishReq> Finishes = new List<ScrobbleFinishReq>();
+            public int AchievementUploads;
+            public AchievementsDiffSyncReq AchievementDiff;
+            public string QueueId = "job";
+            public string QueueStatus = "completed";
+            public Func<Task<QueueStatusRes>> OnQueueStatus;
+            private AsyncQueuedResponse Queued() => new AsyncQueuedResponse { success = true, status = "queued", queueId = QueueId };
+            public Task<ScrobbleStartRes> StartGameSession(ScrobbleStartReq req) => OnStart(req);
+            public Task<ScrobbleFinishRes> FinishGameSession(ScrobbleFinishReq req) { Finishes.Add(req); return OnFinish(req); }
+            public Task<AsyncQueuedResponse> SyncLibraryFull(LibraryFullSyncReq req) => throw new NotSupportedException();
+            public Task<AsyncQueuedResponse> SyncLibraryDiff(LibraryDiffSyncReq req) => Task.FromResult(Queued());
+            public Task<V4SyncBeginRes> SyncLibraryFullBegin(LibraryV4FullSyncBeginReq req) => Task.FromResult(new V4SyncBeginRes { success = true, status = "started", sync_id = "sync", max_chunk_items = 500 });
+            public Task<V4SyncChunkRes> SyncLibraryFullChunk(LibraryV4ChunkReq req) => Task.FromResult(new V4SyncChunkRes { success = true, status = "accepted", sync_id = "sync", chunk_index = req.chunk_index });
+            public Task<AsyncQueuedResponse> SyncLibraryFullCommit(LibraryV4CommitReq req) => Task.FromResult(Queued());
+            public Task SyncLibraryFullAbort(string syncId) => Task.CompletedTask;
+            public Task<AsyncQueuedResponse> SyncAchievementsFull(AchievementsFullSyncReq req) => throw new NotSupportedException();
+            public Task<AsyncQueuedResponse> SyncAchievementsDiff(AchievementsDiffSyncReq req) { AchievementUploads++; AchievementDiff = req; return Task.FromResult(Queued()); }
+            public Task<V4SyncBeginRes> SyncAchievementsFullBegin(AchievementsV4FullSyncBeginReq req) { AchievementUploads++; return Task.FromResult(new V4SyncBeginRes { success = true, status = "started", sync_id = "sync", max_chunk_items = 500 }); }
+            public Task<V4SyncChunkRes> SyncAchievementsFullChunk(AchievementsV4ChunkReq req) => Task.FromResult(new V4SyncChunkRes { success = true, status = "accepted", sync_id = "sync", chunk_index = req.chunk_index });
+            public Task<AsyncQueuedResponse> SyncAchievementsFullCommit(AchievementsV4CommitReq req) => Task.FromResult(Queued());
+            public Task SyncAchievementsFullAbort(string syncId) => Task.CompletedTask;
+            public Task<QueueStatusRes> GetQueueStatus(string queueId) => OnQueueStatus != null
+                ? OnQueueStatus()
+                : Task.FromResult(new QueueStatusRes { success = true, data = new QueueStatusData { status = QueueStatus } });
+            public Task<AllowedPluginsRes> GetAllowedPlugins() => throw new NotSupportedException();
+            public Task<TokenVerificationRes> VerifyToken(string token, string playniteId) => throw new NotSupportedException();
+            public Task FlushPendingScrobblesAsync() => throw new NotSupportedException();
+            public Task<UnlinkRes> UnlinkAccount() => throw new NotSupportedException();
+            public Task<DeleteDataRes> RequestDeleteMyData(DeleteDataReq req) => throw new NotSupportedException();
+            public Task<OptInRes> RequestOptIn(OptInReq req) => throw new NotSupportedException();
+            public Task<RegisterInstallTokenRes> RegisterInstallToken(string installId) => throw new NotSupportedException();
+            public Task<string> GetDashboardToken() => throw new NotSupportedException();
+            public Task<PlayniteNotificationsRes> GetNotifications() => throw new NotSupportedException();
+        }
+    }
+}

--- a/GsPlugin.Tests/GsTelemetryTests.cs
+++ b/GsPlugin.Tests/GsTelemetryTests.cs
@@ -60,6 +60,21 @@ namespace GsPlugin.Tests {
         }
 
         [Theory]
+        [InlineData(@"D:\Profiles\Alice", @"Error in D:\Profiles\Alice\AppData\state.json", @"Error in C:\Users\%USER%\AppData\state.json")]
+        [InlineData(@"D:\Profiles\Alice", @"'d:\profiles\ALICE'", @"'C:\Users\%USER%'")]
+        [InlineData(@"D:\Profiles\Alice\", @"D:\Profiles\Alice", @"C:\Users\%USER%")]
+        [InlineData(@"D:\Profiles\Alice (QA)+", @"D:\Profiles\Alice (QA)+\state.json", @"C:\Users\%USER%\state.json")]
+        [InlineData(@"D:\Profiles\Alice", @"D:\Profiles\AliceOther\state.json", @"D:\Profiles\AliceOther\state.json")]
+        [InlineData(null, "No user path here", "No user path here")]
+        [InlineData("", "No user path here", "No user path here")]
+        [InlineData("", @"C:\Users\Alice\state.json", @"C:\Users\%USER%\state.json")]
+        [InlineData(@"D:\Profiles\Alice", @"C:\Users\Bob\state.json", @"C:\Users\%USER%\state.json")]
+        public void ProfileRedaction_SupportsRelocatedRootsAndSafeFallback(string profileRoot, string input, string expected) {
+            var regex = GsSentry.CreateUserProfilePathRegex(profileRoot);
+            Assert.Equal(expected, regex.Replace(input, @"C:\Users\%USER%"));
+        }
+
+        [Theory]
         [InlineData("no-sentry")]
         [InlineData("no-posthog")]
         public async Task Transport_DiscardsBufferedWorkAfterPreferenceWithdrawal(string flag) {

--- a/GsPlugin.Tests/GsTelemetryTests.cs
+++ b/GsPlugin.Tests/GsTelemetryTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using GsPlugin.Infrastructure;
+using GsPlugin.Models;
+using Sentry;
+using Xunit;
+
+namespace GsPlugin.Tests {
+    [Collection("StaticManagerTests")]
+    public class GsTelemetryTests {
+        [Fact]
+        public async Task SentryLifecycle_StopsOwnedSdkAndAutomaticTrafficWhenDisabled() {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var transport = new CountingHandler();
+                try {
+                    Exception initializationError = null;
+                    GsSentry.InitializeWithHandler(() => transport, error => initializationError = error);
+                    Assert.True(GsSentry.IsInitialized, "Plugin Sentry initialization failed: " + initializationError);
+                    Assert.True(SentrySdk.IsEnabled, "The Sentry hub is disabled after initialization.");
+                    GsSentry.CaptureMessage("synthetic startup test");
+                    await SentrySdk.FlushAsync(TimeSpan.FromSeconds(2));
+                    Assert.True(transport.Calls > 0, "No synthetic envelope reached the mock transport.");
+
+                    GsDataManager.MutateAndSave(d => d.UpdateFlags(true, false, true));
+                    var beforeShutdown = transport.Calls;
+                    GsSentry.ApplyPreferences();
+                    Assert.False(GsSentry.IsInitialized);
+                    Assert.Equal(beforeShutdown, transport.Calls);
+                    GsSentry.CaptureException(new InvalidOperationException("synthetic disabled error"));
+                    Assert.Equal(beforeShutdown, transport.Calls);
+                }
+                finally {
+                    GsSentry.Shutdown();
+                }
+            }
+        }
+
+        [Fact]
+        public void Initialize_WithTelemetryDisabled_InitializesTypeWithoutStartingSdk() {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                GsDataManager.MutateAndSave(d => d.UpdateFlags(true, false, true));
+                // Exercises the same static initializer that previously threw on plugin startup.
+                GsSentry.Initialize();
+                GsSentry.ApplyPreferences();
+                GsPostHog.ApplyPreferences();
+                Assert.False(GsSentry.IsInitialized);
+            }
+        }
+
+        [Theory]
+        [InlineData(@"Could not read C:\Users\Alice\AppData\state.json", @"Could not read C:\Users\%USER%\AppData\state.json")]
+        [InlineData(@"Could not read 'D:\Users\Alice Jones\state.json'", @"Could not read 'C:\Users\%USER%\state.json'")]
+        [InlineData(@"C:\Users\کاربر\state.json", @"C:\Users\%USER%\state.json")]
+        [InlineData("No user path here", "No user path here")]
+        public void ScrubText_RemovesProfileNameWithoutBreakingThePath(string input, string expected) {
+            Assert.Equal(expected, GsSentry.ScrubText(input));
+        }
+
+        [Theory]
+        [InlineData("no-sentry")]
+        [InlineData("no-posthog")]
+        public async Task Transport_DiscardsBufferedWorkAfterPreferenceWithdrawal(string flag) {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var transport = new CountingHandler();
+                var consent = new GsTelemetryConsent(flag);
+                using (var client = new HttpClient(new GsTelemetryConsentHandler(consent, transport))) {
+                    using (await client.PostAsync("https://telemetry.invalid/batch", new StringContent("before"))) { }
+                    Assert.Equal(1, transport.Calls);
+
+                    GsDataManager.MutateAndSave(d => d.Flags.Add(flag));
+                    using (await client.PostAsync("https://telemetry.invalid/batch", new StringContent("buffered"))) { }
+                    Assert.Equal(1, transport.Calls);
+
+                    consent.Revoke();
+                    GsDataManager.MutateAndSave(d => d.Flags.Remove(flag));
+                    using (await client.PostAsync("https://telemetry.invalid/batch", new StringContent("old-worker"))) { }
+                    Assert.Equal(1, transport.Calls);
+                    Assert.True(new GsTelemetryConsent(flag).IsAllowed);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("no-sentry")]
+        [InlineData("no-posthog")]
+        public async Task Transport_StopsAutomaticTrafficAfterDataDeletion(string flag) {
+            using (var temp = TempPluginDir.CreateWithDataManager()) {
+                var transport = new CountingHandler();
+                using (var client = new HttpClient(new GsTelemetryConsentHandler(new GsTelemetryConsent(flag), transport))) {
+                    GsDataManager.PerformOptOut();
+                    using (await client.PostAsync("https://telemetry.invalid/session", new StringContent("automatic-session-end"))) { }
+                    Assert.Equal(0, transport.Calls);
+                }
+            }
+        }
+
+        private sealed class CountingHandler : HttpMessageHandler {
+            public int Calls { get; private set; }
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+                Calls++;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{}") });
+            }
+        }
+    }
+}

--- a/GsPlugin.Tests/HashContractTests.cs
+++ b/GsPlugin.Tests/HashContractTests.cs
@@ -135,6 +135,92 @@ namespace GsPlugin.Tests {
             Assert.Equal("", GsHashUtils.FormatDateForHash(null));
         }
 
+        /// <summary>
+        /// The achievement recipe had no vector on either side of the contract, while
+        /// the library recipe had two. It gates the same force-full-sync loop: a
+        /// disagreement here makes every achievements diff mismatch its baseline, and
+        /// the client re-uploads in full forever without surfacing an error.
+        ///
+        /// The names deliberately sort differently under ordinal and linguistic
+        /// comparers, so a comparer swap on either side turns this red.
+        /// </summary>
+        [Fact]
+        public void Achievement_hash_matches_the_shared_digest() {
+            var fixture = LoadFixture().GetProperty("achievements");
+            var games = ReadAchievementGames(fixture);
+
+            Assert.Equal(
+                fixture.GetProperty("achievementHashV2").GetString(),
+                GsHashUtils.ComputeAchievementHash(games));
+        }
+
+        /// <summary>
+        /// Per-game keys are ordinal-sorted before hashing, so the order games arrive
+        /// in must not change the digest. Providers do not guarantee an order.
+        /// </summary>
+        [Fact]
+        public void Achievement_hash_is_independent_of_game_order() {
+            var fixture = LoadFixture().GetProperty("achievements");
+            var games = ReadAchievementGames(fixture);
+            var reversed = new List<GameAchievementsDto>(games);
+            reversed.Reverse();
+
+            Assert.Equal(
+                GsHashUtils.ComputeAchievementHash(games),
+                GsHashUtils.ComputeAchievementHash(reversed));
+        }
+
+        /// <summary>
+        /// A null name and an empty name must hash identically. string.Join renders a
+        /// null as "", but JS Array.sort coerces null via ToString to the literal
+        /// "null" and orders it among the n's -- so a null reaching the wire would
+        /// give the two sides different digests. The DTO builders normalize to "";
+        /// this pins that the recipe agrees with that choice.
+        /// </summary>
+        [Fact]
+        public void Achievement_hash_treats_a_null_name_as_empty() {
+            var withNull = new List<GameAchievementsDto> {
+                new GameAchievementsDto {
+                    playnite_id = "g",
+                    achievements = new List<AchievementItemDto> {
+                        new AchievementItemDto { name = null, is_unlocked = false },
+                        new AchievementItemDto { name = "A", is_unlocked = true }
+                    }
+                }
+            };
+            var withEmpty = new List<GameAchievementsDto> {
+                new GameAchievementsDto {
+                    playnite_id = "g",
+                    achievements = new List<AchievementItemDto> {
+                        new AchievementItemDto { name = "", is_unlocked = false },
+                        new AchievementItemDto { name = "A", is_unlocked = true }
+                    }
+                }
+            };
+
+            Assert.Equal(
+                GsHashUtils.ComputeAchievementHash(withEmpty),
+                GsHashUtils.ComputeAchievementHash(withNull));
+        }
+
+        private static List<GameAchievementsDto> ReadAchievementGames(JsonElement fixture) {
+            var games = new List<GameAchievementsDto>();
+            foreach (var g in fixture.GetProperty("games").EnumerateArray()) {
+                var achievements = new List<AchievementItemDto>();
+                foreach (var a in g.GetProperty("achievements").EnumerateArray()) {
+                    achievements.Add(new AchievementItemDto {
+                        name = Str(a, "name"),
+                        is_unlocked = a.GetProperty("is_unlocked").GetBoolean()
+                    });
+                }
+                games.Add(new GameAchievementsDto {
+                    playnite_id = Str(g, "playnite_id"),
+                    achievements = achievements
+                });
+            }
+            return games;
+        }
+
         private static GameSyncDto ReadGame(JsonElement e) => new GameSyncDto {
             playnite_id = Str(e, "playnite_id"),
             game_name = Str(e, "game_name"),

--- a/GsPlugin.Tests/PlayniteAchievementsSqliteTests.cs
+++ b/GsPlugin.Tests/PlayniteAchievementsSqliteTests.cs
@@ -139,6 +139,9 @@ namespace GsPlugin.Tests {
             CreateTestDatabase();
             var helper = CreateHelper();
             Assert.Null(helper.GetAchievements(Guid.NewGuid()));
+            var read = helper.ReadAchievements(Guid.NewGuid());
+            Assert.True(read.IsAvailable);
+            Assert.Empty(read.Achievements);
         }
 
         [Fact]
@@ -224,6 +227,7 @@ namespace GsPlugin.Tests {
             File.WriteAllText(_dbPath, "this is not a database");
             var helper = CreateHelper();
             Assert.Null(helper.GetAchievements(Guid.NewGuid()));
+            Assert.False(helper.ReadAchievements(Guid.NewGuid()).IsAvailable);
         }
 
         [Fact]

--- a/GsPlugin.Tests/SuccessStoryFileReaderTests.cs
+++ b/GsPlugin.Tests/SuccessStoryFileReaderTests.cs
@@ -56,6 +56,9 @@ namespace GsPlugin.Tests {
             var helper = CreateHelper();
             var result = helper.GetAchievements(gameId);
             Assert.Null(result);
+            var read = helper.ReadAchievements(gameId);
+            Assert.True(read.IsAvailable);
+            Assert.Empty(read.Achievements);
         }
 
         [Fact]
@@ -171,6 +174,7 @@ namespace GsPlugin.Tests {
             var helper = CreateHelper();
             var result = helper.GetAchievements(gameId);
             Assert.Null(result);
+            Assert.False(helper.ReadAchievements(gameId).IsAvailable);
         }
 
         [Fact]

--- a/GsPlugin.cs
+++ b/GsPlugin.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -37,16 +38,62 @@ namespace GsPlugin {
                 if (string.IsNullOrEmpty(name.Name) || name.Name.StartsWith("Playnite", StringComparison.OrdinalIgnoreCase)) {
                     return null;
                 }
-                var path = Path.Combine(pluginDir, name.Name + ".dll");
-                if (File.Exists(path)) {
-                    return Assembly.LoadFrom(path);
+
+                // Strip any directory component before combining. The requested name is not
+                // ours to trust, and Path.Combine would happily follow "..\..\x" out of the
+                // plugin directory. Belt-and-braces: File.Exists below already confines the
+                // load, but the intent is that only a bare file name is ever considered.
+                var fileName = Path.GetFileName(name.Name);
+                if (string.IsNullOrEmpty(fileName) || fileName != name.Name) {
+                    return null;
                 }
-                return null;
+
+                var path = Path.Combine(pluginDir, fileName + ".dll");
+                if (!File.Exists(path)) {
+                    return null;
+                }
+
+                // Match on identity, not just simple name. This handler is registered on the
+                // shared AppDomain, so it is asked to resolve every extension's failures too.
+                // The plugin ships very common assemblies (System.Text.Json, System.Memory,
+                // Sentry, Microsoft.Extensions.*), and answering another extension's request
+                // for, say, System.Text.Json 4.0.1.0 with our 9.x is a silent downgrade or
+                // upgrade of a dependency that extension was never compiled against.
+                // Serve only an assembly whose public key token matches and whose version is
+                // at least what the caller asked for.
+                try {
+                    var candidate = AssemblyName.GetAssemblyName(path);
+                    var wantedToken = name.GetPublicKeyToken();
+                    var candidateToken = candidate.GetPublicKeyToken();
+                    bool tokensMatch =
+                        wantedToken == null || wantedToken.Length == 0
+                        || (candidateToken != null && wantedToken.SequenceEqual(candidateToken));
+                    if (!tokensMatch) {
+                        return null;
+                    }
+                    if (name.Version != null && candidate.Version != null && candidate.Version < name.Version) {
+                        return null;
+                    }
+                }
+                catch {
+                    // Unreadable metadata — decline rather than guess.
+                    return null;
+                }
+
+                return Assembly.LoadFrom(path);
             };
 
             // UnobservedTaskException handling is centralized in GsSentry.Initialize()
             // which filters by plugin origin, captures to Sentry, and calls SetObserved().
         }
+        /// <summary>
+        /// Private WebView2 profile directory, kept inside the plugin's own data folder. The default
+        /// profile is derived from the host process and is therefore shared by every Playnite
+        /// extension that hosts a WebView2 — including the dashboard's authenticated cookies and the
+        /// URL history holding its access_token.
+        /// </summary>
+        private string WebViewUserDataFolder => Path.Combine(GetPluginUserDataPath(), "WebView2");
+
         private GsPluginSettingsViewModel _settings { get; set; }
         private GsApiClient _apiClient;
         private GsAccountLinkingService _linkingService;
@@ -374,7 +421,7 @@ namespace GsPlugin {
                 return null;
             }
             if (args.Name == "Dashboard") {
-                return new MySidebarView(_apiClient);
+                return new MySidebarView(_apiClient, WebViewUserDataFolder);
             }
             return null;
         }
@@ -405,7 +452,7 @@ namespace GsPlugin {
                 Title = "Game Scrobbler",
                 Icon = iconImage,
                 Opened = () => {
-                    return new MySidebarView(_apiClient);
+                    return new MySidebarView(_apiClient, WebViewUserDataFolder);
                 },
             };
         }
@@ -436,7 +483,7 @@ namespace GsPlugin {
                     window.Title = "Game Scrobbler Dashboard";
                     window.Width = 1200;
                     window.Height = 800;
-                    window.Content = new MySidebarView(_apiClient);
+                    window.Content = new MySidebarView(_apiClient, WebViewUserDataFolder);
                     window.Owner = PlayniteApi.Dialogs.GetCurrentAppWindow();
                     window.WindowStartupLocation = System.Windows.WindowStartupLocation.CenterOwner;
                     window.ShowDialog();

--- a/GsPlugin.cs
+++ b/GsPlugin.cs
@@ -88,12 +88,6 @@ namespace GsPlugin {
             // Initialize snapshot manager for diff-based sync
             GsSyncHashIndex.Initialize(GetPluginUserDataPath());
 
-            // Initialize Sentry for error tracking
-            GsSentry.Initialize();
-
-            // Initialize PostHog for product analytics
-            GsPostHog.Initialize();
-
             // Initialize API client
             _apiClient = new GsApiClient();
 
@@ -107,6 +101,9 @@ namespace GsPlugin {
 
             // Create settings with linking service and achievement helper dependencies
             _settings = new GsPluginSettingsViewModel(this, _linkingService, _achievementHelper, _apiClient);
+            // Load saved privacy preferences before starting either telemetry SDK.
+            GsSentry.ApplyPreferences();
+            GsPostHog.ApplyPreferences();
             Properties = new GenericPluginProperties {
                 HasSettings = true
             };

--- a/GsPlugin.cs
+++ b/GsPlugin.cs
@@ -63,12 +63,7 @@ namespace GsPlugin {
                 // at least what the caller asked for.
                 try {
                     var candidate = AssemblyName.GetAssemblyName(path);
-                    var wantedToken = name.GetPublicKeyToken();
-                    var candidateToken = candidate.GetPublicKeyToken();
-                    bool tokensMatch =
-                        wantedToken == null || wantedToken.Length == 0
-                        || (candidateToken != null && wantedToken.SequenceEqual(candidateToken));
-                    if (!tokensMatch) {
+                    if (!GsAssemblyIdentity.PublicKeyTokensMatch(name, candidate)) {
                         return null;
                     }
                     if (name.Version != null && candidate.Version != null && candidate.Version < name.Version) {

--- a/GsPlugin.csproj
+++ b/GsPlugin.csproj
@@ -27,7 +27,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/GsPlugin.csproj
+++ b/GsPlugin.csproj
@@ -161,6 +161,7 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Infrastructure -->
+    <Compile Include="Infrastructure\GsAssemblyIdentity.cs" />
     <Compile Include="Infrastructure\GsAtomicFile.cs" />
     <Compile Include="Infrastructure\GsLocalization.cs" />
     <Compile Include="Infrastructure\GsLogger.cs" />

--- a/GsPlugin.csproj
+++ b/GsPlugin.csproj
@@ -168,6 +168,7 @@
     <Compile Include="Infrastructure\GsPlayniteHelper.cs" />
     <Compile Include="Infrastructure\GsSentry.cs" />
     <Compile Include="Infrastructure\GsTaskExtensions.cs" />
+    <Compile Include="Infrastructure\GsTelemetryConsent.cs" />
     <!-- Api -->
     <Compile Include="Api\CanonicalDateTimeConverter.cs" />
     <Compile Include="Api\Dtos.cs" />

--- a/Infrastructure/GsAssemblyIdentity.cs
+++ b/Infrastructure/GsAssemblyIdentity.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace GsPlugin.Infrastructure {
+    /// <summary>Identity checks used before resolving a dependency in Playnite's shared AppDomain.</summary>
+    internal static class GsAssemblyIdentity {
+        /// <summary>Unsigned identities match only other unsigned identities, never a signed candidate.</summary>
+        internal static bool PublicKeyTokensMatch(AssemblyName requested, AssemblyName candidate) {
+            var requestedToken = requested.GetPublicKeyToken() ?? Array.Empty<byte>();
+            var candidateToken = candidate.GetPublicKeyToken() ?? Array.Empty<byte>();
+            return requestedToken.SequenceEqual(candidateToken);
+        }
+    }
+}

--- a/Infrastructure/GsAtomicFile.cs
+++ b/Infrastructure/GsAtomicFile.cs
@@ -62,6 +62,12 @@ namespace GsPlugin.Infrastructure {
             var tempPath = filePath + ".tmp";
             using (var stream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None)) {
                 JsonSerializer.Serialize(stream, value, options);
+                // Force the bytes to the physical disk before the replace below. File.Replace is
+                // atomic for the directory-entry swap, but without this the temp file's contents may
+                // still be sitting in the OS write cache, so a power loss can commit the rename over
+                // a zero-length or truncated file. RecoverTemp cannot help there: the destination now
+                // exists, so it is never promoted.
+                stream.Flush(flushToDisk: true);
             }
             ReplaceWithRetry(tempPath, filePath);
         }

--- a/Infrastructure/GsPostHog.cs
+++ b/Infrastructure/GsPostHog.cs
@@ -14,6 +14,14 @@ namespace GsPlugin.Infrastructure {
     public static class GsPostHog {
         private static readonly ILogger _logger = LogManager.GetLogger();
         private static PostHogClient _client;
+        private static readonly object LifecycleLock = new object();
+        private static GsTelemetryConsent _consent;
+        private static GsTelemetryHttpClientFactory _httpClientFactory;
+
+        public static void ApplyPreferences() {
+            if (GsTelemetryConsent.HasConsent("no-posthog")) Initialize();
+            else Shutdown();
+        }
 
         private const string ApiKey = "phc_la6sOuOYr4cEb9Rpq27MMi6Mv8EhCLsVi6ovp6azdSi";
         private const string HostUrl = "https://eu.i.posthog.com";
@@ -23,6 +31,13 @@ namespace GsPlugin.Infrastructure {
         /// Must be called after GsDataManager.Initialize().
         /// </summary>
         public static void Initialize() {
+            lock (LifecycleLock) {
+                if (_client != null) return;
+                InitializeCore();
+            }
+        }
+
+        private static void InitializeCore() {
             try {
                 if (GsDataManager.DataOrNull == null) {
                     _logger.Warn("PostHog init skipped: GsDataManager not initialized");
@@ -39,11 +54,16 @@ namespace GsPlugin.Infrastructure {
                     HostUrl = new Uri(HostUrl)
                 });
 
-                _client = new PostHogClient(options);
+                _consent = new GsTelemetryConsent("no-posthog");
+                _httpClientFactory = new GsTelemetryHttpClientFactory(_consent);
+                _client = new PostHogClient(options, httpClientFactory: _httpClientFactory);
 
                 _logger.Info("PostHog analytics initialized");
             }
             catch (Exception ex) {
+                _consent?.Revoke();
+                _httpClientFactory?.Dispose();
+                _httpClientFactory = null;
                 _logger.Error(ex, "Failed to initialize PostHog (non-critical)");
             }
         }
@@ -92,8 +112,18 @@ namespace GsPlugin.Infrastructure {
         /// Shuts down the PostHog client and releases resources.
         /// </summary>
         public static void Shutdown() {
+            lock (LifecycleLock) {
+                ShutdownCore();
+            }
+        }
+
+        private static void ShutdownCore() {
             var client = _client;
+            var factory = _httpClientFactory;
+            var consent = _consent;
+            if (!GsTelemetryConsent.HasConsent("no-posthog")) consent?.Revoke();
             _client = null;
+            _httpClientFactory = null;
             if (client == null) {
                 return;
             }
@@ -103,7 +133,13 @@ namespace GsPlugin.Infrastructure {
                 // async flush (DisposeAsync().GetAwaiter().GetResult()), which can hang Playnite
                 // on exit when the ingest endpoint is slow/unreachable. Race it against a timeout
                 // instead of waiting on it directly.
-                var disposeTask = Task.Run(() => client.Dispose());
+                var disposeTask = Task.Run(() => {
+                    try { client.Dispose(); }
+                    finally {
+                        consent?.Revoke();
+                        factory?.Dispose();
+                    }
+                });
                 if (!disposeTask.Wait(TimeSpan.FromSeconds(2))) {
                     _logger.Warn("PostHog dispose timed out during shutdown; abandoning");
                     // Dispose keeps running in the background after we give up waiting on it —

--- a/Infrastructure/GsSentry.cs
+++ b/Infrastructure/GsSentry.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Playnite.SDK;
 using Sentry;
 using GsPlugin.Models;
@@ -14,6 +15,11 @@ namespace GsPlugin.Infrastructure {
     public class GsSentry {
         private static readonly ILogger _logger = LogManager.GetLogger();
         private static bool _initialized;
+        private static readonly object LifecycleLock = new object();
+        private static GsTelemetryConsent _consent;
+        private static IDisposable _sdkLifetime;
+        private static UnhandledExceptionEventHandler _unhandledExceptionHandler;
+        private static EventHandler<System.Threading.Tasks.UnobservedTaskExceptionEventArgs> _unobservedTaskExceptionHandler;
 
         /// <summary>
         /// True when <see cref="Initialize"/> completed successfully.
@@ -24,14 +30,42 @@ namespace GsPlugin.Infrastructure {
         /// Initializes Sentry with appropriate configuration settings.
         /// </summary>
         public static void Initialize() {
+            InitializeWithHandler(null);
+        }
+
+        internal static void InitializeWithHandler(Func<System.Net.Http.HttpMessageHandler> createHandler, Action<Exception> onError = null) {
+            lock (LifecycleLock) {
+                if (_initialized) return;
+                InitializeCore(createHandler, onError);
+            }
+        }
+
+        /// <summary>Applies settings changes to the running SDK, including automatic capture.</summary>
+        public static void ApplyPreferences() {
+            if (GsTelemetryConsent.HasConsent("no-sentry")) Initialize();
+            else Shutdown();
+        }
+
+        private static void InitializeCore(Func<System.Net.Http.HttpMessageHandler> createHandler, Action<Exception> onError) {
             try {
                 _logger.Info("Initializing Sentry error tracking");
 
                 // Set sampling rates based on user preference or opt-out
-                bool disableSentryFlag = GsDataManager.Data.Flags.Contains("no-sentry")
-                    || GsDataManager.IsOptedOut;
+                bool disableSentryFlag = !GsTelemetryConsent.HasConsent("no-sentry");
 
-                SentrySdk.Init(options => {
+                if (disableSentryFlag) {
+                    // Previously Init still ran with SampleRate 0. That leaves AutoSessionTracking
+                    // posting session envelopes and SendClientReports (default true) periodically
+                    // POSTing discarded-event counts -- network traffic from an install that asked
+                    // for none. Not initializing is the only way to be silent; the Capture* wrappers
+                    // below already no-op, so nothing else needs to change.
+                    _logger.Info("Sentry disabled by user preference or opt-out — not initializing");
+                    return;
+                }
+
+                var consent = new GsTelemetryConsent("no-sentry");
+                _consent = consent;
+                _sdkLifetime = SentrySdk.Init(options => {
                     // A Sentry Data Source Name (DSN) is required.
                     // See https://docs.sentry.io/product/sentry-basics/dsn-explainer/
                     options.Dsn = "https://af79b5bda2a052b04b3f490b79d0470a@o4508777256124416.ingest.de.sentry.io/4508777265627216";
@@ -82,15 +116,22 @@ namespace GsPlugin.Infrastructure {
                     // Filter out events that don't originate from our plugin.
                     // Without this, Sentry's global hooks capture unhandled exceptions
                     // from other Playnite plugins and Playnite core, polluting our dashboard.
+                    options.SendClientReports = false;
+                    options.ShutdownTimeout = TimeSpan.FromSeconds(2);
+                    options.CreateHttpMessageHandler = () =>
+                        new GsTelemetryConsentHandler(consent, createHandler?.Invoke() ?? new System.Net.Http.HttpClientHandler());
+                    options.SetBeforeSendTransaction(transaction => consent.IsAllowed ? transaction : null);
+
                     options.SetBeforeSend((sentryEvent, hint) => {
+                        if (!consent.IsAllowed) return null;
                         // Always allow explicitly captured messages (our own CaptureMessage calls)
                         if (sentryEvent.Exception == null) {
-                            return sentryEvent;
+                            return Scrub(sentryEvent);
                         }
 
                         // Check if any exception in the chain originates from our assembly
                         if (IsExceptionFromOurPlugin(sentryEvent.Exception)) {
-                            return sentryEvent;
+                            return Scrub(sentryEvent);
                         }
 
                         // Also check SentryExceptions (populated from the event's exception list)
@@ -98,12 +139,12 @@ namespace GsPlugin.Infrastructure {
                             var ourNamespace = "GsPlugin";
                             foreach (var se in sentryEvent.SentryExceptions) {
                                 if (se.Module != null && se.Module.StartsWith(ourNamespace)) {
-                                    return sentryEvent;
+                                    return Scrub(sentryEvent);
                                 }
                                 if (se.Stacktrace?.Frames != null) {
                                     foreach (var frame in se.Stacktrace.Frames) {
                                         if (frame.Module != null && frame.Module.StartsWith(ourNamespace)) {
-                                            return sentryEvent;
+                                            return Scrub(sentryEvent);
                                         }
                                     }
                                 }
@@ -133,7 +174,7 @@ namespace GsPlugin.Infrastructure {
                 }
 
                 // Hook global exception handlers to prevent UnobservedTaskException crashes and capture in Sentry
-                AppDomain.CurrentDomain.UnhandledException += (s, e) => {
+                _unhandledExceptionHandler = (s, e) => {
                     try {
                         var ex = e.ExceptionObject as Exception;
                         if (ex != null) {
@@ -156,8 +197,9 @@ namespace GsPlugin.Infrastructure {
                         try { _logger.Debug(handlerEx, "Exception in UnhandledException handler"); } catch { }
                     }
                 };
+                AppDomain.CurrentDomain.UnhandledException += _unhandledExceptionHandler;
 
-                System.Threading.Tasks.TaskScheduler.UnobservedTaskException += (s, e) => {
+                _unobservedTaskExceptionHandler = (s, e) => {
                     try {
                         // Filter: only capture if exception originates from our plugin assembly to avoid reporting other extensions' errors
                         bool fromUs = IsExceptionFromOurPlugin(e.Exception);
@@ -177,13 +219,16 @@ namespace GsPlugin.Infrastructure {
                         try { _logger.Debug(handlerEx, "Exception in UnobservedTaskException handler"); } catch { }
                     }
                 };
+                System.Threading.Tasks.TaskScheduler.UnobservedTaskException += _unobservedTaskExceptionHandler;
 
                 _initialized = true;
                 _logger.Info($"Sentry initialized. Tracking enabled: {!disableSentryFlag}");
             }
             catch (Exception ex) {
-                _initialized = false;
+                _consent?.Revoke();
+                ShutdownCore();
                 _logger.Error(ex, "Failed to initialize Sentry");
+                onError?.Invoke(ex);
             }
         }
 
@@ -192,26 +237,40 @@ namespace GsPlugin.Infrastructure {
         /// Safe to call when init failed — no-ops so Playnite can exit promptly.
         /// </summary>
         public static void Shutdown() {
-            if (!_initialized) {
+            lock (LifecycleLock) {
+                ShutdownCore();
+            }
+        }
+
+        private static void ShutdownCore() {
+            // On consent withdrawal, revoke before disposing: SDK disposal can emit a final
+            // automatic-session envelope or flush work queued before the preference changed.
+            if (!GsTelemetryConsent.HasConsent("no-sentry")) _consent?.Revoke();
+            if (_unhandledExceptionHandler != null) {
+                AppDomain.CurrentDomain.UnhandledException -= _unhandledExceptionHandler;
+                _unhandledExceptionHandler = null;
+            }
+            if (_unobservedTaskExceptionHandler != null) {
+                System.Threading.Tasks.TaskScheduler.UnobservedTaskException -= _unobservedTaskExceptionHandler;
+                _unobservedTaskExceptionHandler = null;
+            }
+            if (_sdkLifetime == null) {
+                _consent?.Revoke();
+                _initialized = false;
                 return;
             }
 
             try {
-                // Bounded flush: an unbounded Close() can hang Playnite on exit when the
-                // ingest endpoint is slow/unreachable or session tracking is mid-flight.
-                SentrySdk.Flush(TimeSpan.FromSeconds(2));
-            }
-            catch (Exception ex) {
-                try { _logger.Debug(ex, "Sentry Flush failed during shutdown (non-critical)"); } catch { }
-            }
-
-            try {
-                SentrySdk.Close();
+                // Dispose the hub we initialized, with the configured two-second bound.
+                // Global Flush/Close could act on a hub installed later by another addon.
+                _sdkLifetime?.Dispose();
             }
             catch (Exception ex) {
                 try { _logger.Debug(ex, "Sentry Close failed during shutdown (non-critical)"); } catch { }
             }
             finally {
+                _consent?.Revoke();
+                _sdkLifetime = null;
                 _initialized = false;
             }
         }
@@ -221,6 +280,61 @@ namespace GsPlugin.Infrastructure {
         /// </summary>
         /// <param name="exception">The exception to check.</param>
         /// <returns>True if the exception originated from GsPlugin, false otherwise.</returns>
+        /// <summary>
+        /// Matches a Windows user-profile path so the account name can be replaced. The plugin's
+        /// own data lives under %APPDATA%, so almost every IO exception it reports carries the
+        /// user's real Windows account name inside the path.
+        /// </summary>
+        private static readonly Regex UserProfilePathRegex = new Regex(
+            @"[A-Za-z]:\\Users\\[^\\""'\r\n]+",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        internal static string ScrubText(string value) =>
+            string.IsNullOrEmpty(value)
+                ? value
+                : UserProfilePathRegex.Replace(value, @"C:\Users\%USER%");
+
+        /// <summary>
+        /// Removes personal data from an event immediately before it leaves the device.
+        ///
+        /// SetBeforeSend was only ever an origin filter — it decided whether to send and redacted
+        /// nothing. With StackTraceMode.Enhanced and PDBs uploaded in CI, every IO exception carried
+        /// an absolute path containing the user's Windows account name (the plugin's data file lives
+        /// under %APPDATA%\Playnite\ExtensionsData\...), which is real PII the plugin never intended
+        /// to collect.
+        ///
+        /// Wrapped in try/catch: a scrubbing failure must not take the event down with it, because
+        /// losing crash reports is the worse outcome. On failure the event is returned unchanged,
+        /// matching the previous behaviour.
+        /// </summary>
+        private static SentryEvent Scrub(SentryEvent sentryEvent) {
+            try {
+                if (sentryEvent?.Message != null) {
+                    var scrubbed = ScrubText(sentryEvent.Message.Formatted ?? sentryEvent.Message.Message);
+                    if (!string.IsNullOrEmpty(scrubbed)) {
+                        sentryEvent.Message = scrubbed;
+                    }
+                }
+
+                if (sentryEvent?.SentryExceptions != null) {
+                    foreach (var se in sentryEvent.SentryExceptions) {
+                        se.Value = ScrubText(se.Value);
+                        if (se.Stacktrace?.Frames == null) {
+                            continue;
+                        }
+                        foreach (var frame in se.Stacktrace.Frames) {
+                            frame.AbsolutePath = ScrubText(frame.AbsolutePath);
+                            frame.FileName = ScrubText(frame.FileName);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex) {
+                _logger.Debug(ex, "Sentry PII scrub failed; sending event unscrubbed");
+            }
+            return sentryEvent;
+        }
+
         private static bool IsExceptionFromOurPlugin(Exception exception) {
             if (exception == null) {
                 return false;
@@ -292,6 +406,7 @@ namespace GsPlugin.Infrastructure {
         /// <param name="message">The message to capture.</param>
         /// <param name="level">The severity level of the message.</param>
         public static void CaptureMessage(string message, SentryLevel level = SentryLevel.Info) {
+            if (!_initialized || _consent?.IsAllowed != true) return;
             // Skip if Sentry is disabled, data not yet initialized, or user opted out
             var data = GsDataManager.DataOrNull;
             if (data == null) return;
@@ -313,20 +428,10 @@ namespace GsPlugin.Infrastructure {
         /// <param name="exception">The exception to capture.</param>
         /// <param name="message">An optional message describing the context of the exception.</param>
         public static void CaptureException(Exception exception, string message = null) {
+            if (!_initialized || _consent?.IsAllowed != true) return;
             // Skip if Sentry is disabled or data not yet initialized
             var data = GsDataManager.DataOrNull;
-            if (data == null) {
-                // Data not initialized yet — send without tags to avoid circular dependency
-                try {
-                    SentrySdk.CaptureException(exception, scope => {
-                        if (!string.IsNullOrEmpty(message)) {
-                            scope.SetExtra("contextMessage", message);
-                        }
-                    });
-                }
-                catch (Exception ex) { try { _logger.Debug(ex, "Sentry CaptureException failed (non-critical)"); } catch { } }
-                return;
-            }
+            if (data == null) return;
             if (data.Flags.Contains("no-sentry") || data.OptedOut) return;
 
             try {
@@ -351,6 +456,7 @@ namespace GsPlugin.Infrastructure {
         /// <param name="data">Optional key-value data to attach.</param>
         /// <param name="level">The severity level of the breadcrumb.</param>
         public static void AddBreadcrumb(string message, string category = null, Dictionary<string, string> data = null, BreadcrumbLevel level = BreadcrumbLevel.Info) {
+            if (!_initialized || _consent?.IsAllowed != true) return;
             // Skip if Sentry is disabled or data not yet initialized
             var gsData = GsDataManager.DataOrNull;
             if (gsData == null) return;

--- a/Infrastructure/GsSentry.cs
+++ b/Infrastructure/GsSentry.cs
@@ -285,9 +285,18 @@ namespace GsPlugin.Infrastructure {
         /// own data lives under %APPDATA%, so almost every IO exception it reports carries the
         /// user's real Windows account name inside the path.
         /// </summary>
-        private static readonly Regex UserProfilePathRegex = new Regex(
-            @"[A-Za-z]:\\Users\\[^\\""'\r\n]+",
-            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex UserProfilePathRegex = CreateUserProfilePathRegex(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
+
+        /// <summary>Redacts the actual profile root, including relocated profiles, and standard Windows profile paths.</summary>
+        internal static Regex CreateUserProfilePathRegex(string profileRoot) {
+            const string standardProfile = @"[A-Za-z]:\\Users\\[^\\""'\r\n]+";
+            var root = profileRoot?.TrimEnd('\\', '/');
+            var pattern = string.IsNullOrEmpty(root)
+                ? standardProfile
+                : Regex.Escape(root) + @"(?=$|[\\/""'\s])|" + standardProfile;
+            return new Regex(pattern, RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        }
 
         internal static string ScrubText(string value) =>
             string.IsNullOrEmpty(value)

--- a/Infrastructure/GsTelemetryConsent.cs
+++ b/Infrastructure/GsTelemetryConsent.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using GsPlugin.Models;
+
+namespace GsPlugin.Infrastructure {
+    /// <summary>
+    /// A telemetry client's permission ends permanently when it is stopped. An old SDK
+    /// worker must not send buffered events after the user disables and re-enables telemetry.
+    /// </summary>
+    internal sealed class GsTelemetryConsent {
+        private readonly string _disabledFlag;
+        private int _revoked;
+
+        public GsTelemetryConsent(string disabledFlag) {
+            _disabledFlag = disabledFlag;
+        }
+
+        internal static bool HasConsent(string disabledFlag) {
+            var data = GsDataManager.DataOrNull;
+            return data != null && !data.OptedOut && data.Flags != null
+                && !data.Flags.Contains(disabledFlag);
+        }
+
+        public bool IsAllowed => Volatile.Read(ref _revoked) == 0 && HasConsent(_disabledFlag);
+        public void Revoke() => Interlocked.Exchange(ref _revoked, 1);
+    }
+
+    /// <summary>Checks consent at dispatch, including automatic sessions and buffered batches.</summary>
+    internal sealed class GsTelemetryConsentHandler : DelegatingHandler {
+        private readonly GsTelemetryConsent _consent;
+
+        public GsTelemetryConsentHandler(GsTelemetryConsent consent, HttpMessageHandler innerHandler) : base(innerHandler) {
+            _consent = consent;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            if (!_consent.IsAllowed) {
+                // Acknowledge the discarded batch locally so the SDK doesn't retain/retry it.
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new StringContent("{}"),
+                    RequestMessage = request
+                });
+            }
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+
+    internal sealed class GsTelemetryHttpClientFactory : IHttpClientFactory, IDisposable {
+        private readonly HttpMessageHandler _handler;
+
+        public GsTelemetryHttpClientFactory(GsTelemetryConsent consent) {
+            _handler = new GsTelemetryConsentHandler(consent, new HttpClientHandler());
+        }
+
+        public HttpClient CreateClient(string name) => new HttpClient(_handler, disposeHandler: false);
+        public void Dispose() => _handler.Dispose();
+    }
+}

--- a/Localization/de_DE.xaml
+++ b/Localization/de_DE.xaml
@@ -192,4 +192,5 @@ Möchten Sie ein anderes Konto verknüpfen?</sys:String>
     <sys:String x:Key="LOCGsPluginMenuSyncLibrary">Bibliothek jetzt synchronisieren</sys:String>
     <sys:String x:Key="LOCGsPluginMenuOpenSettings">Einstellungen öffnen</sys:String>
 
+    <sys:String x:Key="LOCGsPluginIdentityChangedDuringRequest">Die Installation wurde während dieser Anfrage geändert oder deaktiviert. Bitte versuchen Sie es erneut.</sys:String>
 </ResourceDictionary>

--- a/Localization/en_US.xaml
+++ b/Localization/en_US.xaml
@@ -192,4 +192,5 @@ Do you want to link to a different account?</sys:String>
     <sys:String x:Key="LOCGsPluginMenuSyncLibrary">Sync Library Now</sys:String>
     <sys:String x:Key="LOCGsPluginMenuOpenSettings">Open Settings</sys:String>
 
+    <sys:String x:Key="LOCGsPluginIdentityChangedDuringRequest">The installation changed or was disabled during this request. Please try again.</sys:String>
 </ResourceDictionary>

--- a/Localization/fr_FR.xaml
+++ b/Localization/fr_FR.xaml
@@ -192,4 +192,5 @@ Voulez-vous associer un autre compte ?</sys:String>
     <sys:String x:Key="LOCGsPluginMenuSyncLibrary">Synchroniser maintenant</sys:String>
     <sys:String x:Key="LOCGsPluginMenuOpenSettings">Ouvrir les paramètres</sys:String>
 
+    <sys:String x:Key="LOCGsPluginIdentityChangedDuringRequest">L’installation a été modifiée ou désactivée pendant cette requête. Veuillez réessayer.</sys:String>
 </ResourceDictionary>

--- a/Localization/hi_IN.xaml
+++ b/Localization/hi_IN.xaml
@@ -192,4 +192,5 @@
     <sys:String x:Key="LOCGsPluginMenuSyncLibrary">अभी लाइब्रेरी सिंक करें</sys:String>
     <sys:String x:Key="LOCGsPluginMenuOpenSettings">सेटिंग्स खोलें</sys:String>
 
+    <sys:String x:Key="LOCGsPluginIdentityChangedDuringRequest">इस अनुरोध के दौरान इंस्टॉलेशन बदल गया या अक्षम कर दिया गया। कृपया फिर से प्रयास करें।</sys:String>
 </ResourceDictionary>

--- a/Localization/pt_BR.xaml
+++ b/Localization/pt_BR.xaml
@@ -192,4 +192,5 @@ Deseja vincular a uma conta diferente?</sys:String>
     <sys:String x:Key="LOCGsPluginMenuSyncLibrary">Sincronizar Biblioteca</sys:String>
     <sys:String x:Key="LOCGsPluginMenuOpenSettings">Abrir Configurações</sys:String>
 
+    <sys:String x:Key="LOCGsPluginIdentityChangedDuringRequest">A instalação foi alterada ou desativada durante esta solicitação. Tente novamente.</sys:String>
 </ResourceDictionary>

--- a/Localization/ru_RU.xaml
+++ b/Localization/ru_RU.xaml
@@ -192,4 +192,5 @@ ID пользователя: {0}</sys:String>
     <sys:String x:Key="LOCGsPluginMenuSyncLibrary">Синхронизировать библиотеку</sys:String>
     <sys:String x:Key="LOCGsPluginMenuOpenSettings">Открыть настройки</sys:String>
 
+    <sys:String x:Key="LOCGsPluginIdentityChangedDuringRequest">Во время запроса установка изменилась или плагин был отключён. Повторите попытку.</sys:String>
 </ResourceDictionary>

--- a/Localization/zh_CN.xaml
+++ b/Localization/zh_CN.xaml
@@ -192,4 +192,5 @@
     <sys:String x:Key="LOCGsPluginMenuSyncLibrary">立即同步库</sys:String>
     <sys:String x:Key="LOCGsPluginMenuOpenSettings">打开设置</sys:String>
 
+    <sys:String x:Key="LOCGsPluginIdentityChangedDuringRequest">此请求期间安装信息已更改或插件已停用。请重试。</sys:String>
 </ResourceDictionary>

--- a/Models/GsData.cs
+++ b/Models/GsData.cs
@@ -135,6 +135,17 @@ namespace GsPlugin.Models {
         /// </summary>
         public int DroppedScrobbleCount { get; set; } = 0;
 
+        internal GsData CreateRollbackSnapshot() {
+            var copy = (GsData)MemberwiseClone();
+            copy.ActiveSessionsByGameId = new Dictionary<string, string>(ActiveSessionsByGameId);
+            copy.PendingStartGameIds = new List<string>(PendingStartGameIds);
+            copy.PendingScrobbles = new List<PendingScrobble>(PendingScrobbles);
+            copy.Flags = new List<string>(Flags);
+            copy.AllowedPlugins = new List<string>(AllowedPlugins);
+            copy.ShownNotificationIds = new List<string>(ShownNotificationIds);
+            return copy;
+        }
+
         /// <summary>
         /// Clears the state bound to the current install/account identity so it cannot bleed into
         /// the next one. Single source of truth for opt-out, install-id rotation and account
@@ -266,6 +277,9 @@ namespace GsPlugin.Models {
         /// Lock object for thread-safe access to _data and file operations.
         /// </summary>
         private static readonly object _lock = new object();
+        // Live event handlers own these durable queue items until their HTTP attempt ends.
+        // Claims are process-local: after a crash all persisted items become replayable.
+        private static readonly HashSet<PendingScrobble> _claimedScrobbles = new HashSet<PendingScrobble>();
 
         private static readonly JsonSerializerOptions jsonOptions = new JsonSerializerOptions {
             WriteIndented = true
@@ -281,31 +295,27 @@ namespace GsPlugin.Models {
         public static void Initialize(string folderPath, string oldID) {
             lock (_lock) {
                 _filePath = Path.Combine(folderPath, "gs_data.json");
-                _data = Load();
-
+                // Never leave an earlier identity usable after a failed initialization.
+                // In particular, an unreadable file is not permission to create a new install.
+                _data = null;
+                _claimedScrobbles.Clear();
                 try {
-                    if (string.IsNullOrEmpty(_data.InstallID)) {
-                        // Generate new InstallID if not present (fresh install or corrupt/missing data file).
-                        // Bumping IdentityGeneration ensures any surviving gs_snapshot.json is treated
-                        // as stale and discarded by GsSyncHashIndex.Initialize().
-                        _data.InstallID = Guid.NewGuid().ToString();
-                        _data.IdentityGeneration++;
+                    var loaded = Load();
+                    if (string.IsNullOrEmpty(loaded.InstallID)) {
+                        loaded.InstallID = Guid.NewGuid().ToString();
+                        loaded.IdentityGeneration++;
+                        Directory.CreateDirectory(folderPath);
+                        GsAtomicFile.WriteJson(_filePath, loaded, jsonOptions);
                         GsLogger.Info("Generated new InstallID");
-                        GsSentry.AddBreadcrumb(
-                            message: "Generated new InstallID",
-                            category: "initialization",
-                            data: new Dictionary<string, string> { { "InstallID", _data.InstallID } }
-                        );
-                        SaveInternal();
                     }
+                    _data = loaded;
                 }
                 catch (Exception ex) {
-                    GsLogger.Error("Failed to initialize GsData", ex);
-                    GsSentry.CaptureException(ex, "Failed to initialize GsData");
-                    // Fallback to new GUID if initialization fails; bump generation for same reason.
-                    _data.InstallID = Guid.NewGuid().ToString();
-                    _data.IdentityGeneration++;
-                    SaveInternal();
+                    // Consent is in the unreadable file, so report locally only. Throwing stops
+                    // plugin construction before registration, telemetry, or sync can run.
+                    _filePath = null;
+                    GsLogger.Error("Cannot load plugin data; preserving the existing file and stopping initialization", ex);
+                    throw;
                 }
             }
         }
@@ -318,20 +328,26 @@ namespace GsPlugin.Models {
         private static GsData Load() {
             GsAtomicFile.RecoverTemp(_filePath);
 
-            if (!File.Exists(_filePath)) {
-                return new GsData();
-            }
-
-            try {
-                var json = File.ReadAllText(_filePath);
-                var data = JsonSerializer.Deserialize<GsData>(json, jsonOptions) ?? new GsData();
-                MigrateLegacySessionFields(data, json);
-                return data;
-            }
-            catch (Exception ex) {
-                GsLogger.Error("Failed to load custom GsData", ex);
-                GsSentry.CaptureException(ex, "Failed to load GsData from disk");
-                return new GsData();
+            for (var attempt = 0; ; attempt++) {
+                try {
+                    var json = File.ReadAllText(_filePath);
+                    var data = JsonSerializer.Deserialize<GsData>(json, jsonOptions);
+                    if (data == null) {
+                        throw new JsonException("Plugin data must contain an object, not null.");
+                    }
+                    MigrateLegacySessionFields(data, json);
+                    return data;
+                }
+                catch (FileNotFoundException) when (!File.Exists(_filePath + ".tmp")) {
+                    return new GsData();
+                }
+                catch (DirectoryNotFoundException) {
+                    return new GsData();
+                }
+                catch (Exception ex) when (attempt < 2 &&
+                    (ex is IOException || ex is UnauthorizedAccessException || ex is JsonException)) {
+                    System.Threading.Thread.Sleep(50 * (attempt + 1));
+                }
             }
         }
 
@@ -396,9 +412,105 @@ namespace GsPlugin.Models {
         /// <param name="action">Action that modifies the <see cref="GsData"/> instance.</param>
         public static void MutateAndSave(Action<GsData> action) {
             lock (_lock) {
-                action(_data);
+                action(Data);
                 SaveInternal();
             }
+        }
+
+        /// <summary>Rejects responses that belong to a deleted or replaced installation.</summary>
+        public static bool TryMutateIfActiveIdentity(string expectedInstallId, int expectedGeneration, Action<GsData> action) {
+            bool saved;
+            lock (_lock) {
+                if (_data == null || _data.OptedOut || _data.InstallID != expectedInstallId
+                    || _data.IdentityGeneration != expectedGeneration) {
+                    return false;
+                }
+                saved = PersistMutation(action);
+            }
+            if (saved) NotifyDiagnosticsChanged();
+            return saved;
+        }
+
+        // Preserve queue item identity across rollback: an in-flight sender holds those same
+        // objects. Only the session ID of a paired finish is edited by these transactions.
+        private static bool PersistMutation(Action<GsData> action) {
+            var before = _data;
+            var claims = new HashSet<PendingScrobble>(_claimedScrobbles);
+            var finishIds = _data.PendingScrobbles.Where(p => p.FinishData != null)
+                .Select(p => p.FinishData).Distinct().ToDictionary(f => f, f => f.session_id);
+            bool saved = false;
+            try {
+                // Work on copied collections so a failed write preserves existing references
+                // as well as their contents. Pending items stay shared for live/replay pairing.
+                _data = before.CreateRollbackSnapshot();
+                action(_data);
+                saved = SaveInternal();
+                return saved;
+            }
+            finally {
+                if (!saved) {
+                    _data = before;
+                    foreach (var finish in finishIds) finish.Key.session_id = finish.Value;
+                    _claimedScrobbles.Clear();
+                    _claimedScrobbles.UnionWith(claims);
+                }
+            }
+        }
+
+        private static bool MutatePendingScrobble(PendingScrobble item, Action<GsData> action) {
+            bool saved;
+            lock (_lock) {
+                if (_data == null || _data.OptedOut || !_data.PendingScrobbles.Contains(item)) return false;
+                saved = PersistMutation(action);
+            }
+            if (saved) NotifyDiagnosticsChanged();
+            return saved;
+        }
+
+        /// <summary>
+        /// Persists every shutdown finish and removes only the corresponding active sessions
+        /// in one write. On a failed write the original collections remain available for retry.
+        /// </summary>
+        public static bool QueueSessionFinishesAndClearActive(Dictionary<string, string> sessions, List<PendingScrobble> finishes,
+            string expectedInstallId = null, int? expectedGeneration = null) {
+            bool saved;
+            lock (_lock) {
+                if (_data == null || _data.OptedOut) return false;
+                if ((expectedInstallId != null && _data.InstallID != expectedInstallId)
+                    || (expectedGeneration.HasValue && _data.IdentityGeneration != expectedGeneration.Value)) return false;
+                saved = PersistMutation(d => {
+                    foreach (var pending in finishes) {
+                        var finish = pending.FinishData;
+                        if (string.IsNullOrEmpty(finish.session_id)
+                            && !d.PendingScrobbles.Any(p => p.Type == "start"
+                                && IsSameGame(p, finish.game_id, finish.plugin_id))) {
+                            // A start can complete after shutdown takes its active-session
+                            // snapshot. Resolve that response within the same durable write.
+                            if (d.ActiveSessionsByGameId.TryGetValue(finish.game_id, out var completedSession)) {
+                                finish.session_id = completedSession;
+                            }
+                            else if (!d.PendingStartGameIds.Contains(finish.game_id)) {
+                                continue; // The start was already dropped or the game stopped.
+                            }
+                        }
+                        d.PendingScrobbles.Add(pending);
+                        d.PendingStartGameIds.Remove(finish.game_id);
+                        if (!string.IsNullOrEmpty(finish.session_id)
+                            && d.ActiveSessionsByGameId.TryGetValue(finish.game_id, out var active)
+                            && active == finish.session_id) {
+                            d.ActiveSessionsByGameId.Remove(finish.game_id);
+                        }
+                    }
+                    foreach (var session in sessions) {
+                        if (d.ActiveSessionsByGameId.TryGetValue(session.Key, out var current)
+                            && current == session.Value) {
+                            d.ActiveSessionsByGameId.Remove(session.Key);
+                        }
+                    }
+                });
+            }
+            if (saved) NotifyDiagnosticsChanged();
+            return saved;
         }
 
         /// <summary>
@@ -444,7 +556,8 @@ namespace GsPlugin.Models {
         /// <summary>
         /// Internal save implementation. Must be called under _lock.
         /// </summary>
-        private static void SaveInternal() {
+        private static bool SaveInternal() {
+            if (_data == null || string.IsNullOrEmpty(_filePath)) return false;
             try {
                 var dir = Path.GetDirectoryName(_filePath);
                 if (!Directory.Exists(dir)) {
@@ -452,10 +565,12 @@ namespace GsPlugin.Models {
                 }
                 GsLogger.Info("Saving plugin data to disk");
                 GsAtomicFile.WriteJson(_filePath, _data, jsonOptions);
+                return true;
             }
             catch (Exception ex) {
                 GsLogger.Error("Failed to save custom GsData", ex);
                 GsSentry.CaptureException(ex, "Failed to save GsData to disk");
+                return false;
             }
         }
 
@@ -491,6 +606,7 @@ namespace GsPlugin.Models {
         public static void PerformOptOut() {
             lock (_lock) {
                 _data.OptedOut = true;
+                _data.IdentityGeneration++;
                 // Token is invalidated server-side on opt-out, so clear it too.
                 _data.ClearIdentityBoundState(IdentityClearScope.InstallToken);
                 SaveInternal();
@@ -617,8 +733,104 @@ namespace GsPlugin.Models {
         /// </summary>
         public static List<PendingScrobble> PeekPendingScrobbles() {
             lock (_lock) {
-                return new List<PendingScrobble>(_data.PendingScrobbles);
+                // A claimed start can already have a durable matching finish behind it.
+                // Replay only the available prefix, so that finish cannot overtake its start.
+                return _data.PendingScrobbles.TakeWhile(item => !_claimedScrobbles.Contains(item)).ToList();
             }
+        }
+
+        public static void ClaimPendingScrobble(PendingScrobble item) {
+            lock (_lock) {
+                _claimedScrobbles.Add(item);
+            }
+        }
+
+        public static void ReleasePendingScrobble(PendingScrobble item) {
+            lock (_lock) {
+                _claimedScrobbles.Remove(item);
+            }
+        }
+
+        private static bool IsSameGame(PendingScrobble item, string gameId, string pluginId) =>
+            item.Type == "start"
+                ? item.StartData?.game_id == gameId && item.StartData?.plugin_id == pluginId
+                : item.FinishData?.game_id == gameId && item.FinishData?.plugin_id == pluginId;
+
+        public static bool HasEarlierPendingScrobble(PendingScrobble item) {
+            lock (_lock) {
+                var index = _data.PendingScrobbles.IndexOf(item);
+                var gameId = item.StartData?.game_id ?? item.FinishData?.game_id;
+                var pluginId = item.StartData?.plugin_id ?? item.FinishData?.plugin_id;
+                return _data.PendingScrobbles.Take(Math.Max(0, index))
+                    .Any(p => IsSameGame(p, gameId, pluginId));
+            }
+        }
+
+        // A second start belongs to another launch: never attach its finish to this start.
+        private static PendingScrobble FindPairedFinish(PendingScrobble start) {
+            var startIndex = _data.PendingScrobbles.IndexOf(start);
+            for (var i = startIndex + 1; i < _data.PendingScrobbles.Count; i++) {
+                var candidate = _data.PendingScrobbles[i];
+                if (!IsSameGame(candidate, start.StartData.game_id, start.StartData.plugin_id)) continue;
+                return candidate.Type == "finish" ? candidate : null;
+            }
+            return null;
+        }
+
+        public static bool CompletePendingStart(PendingScrobble item, string sessionId) {
+            if (item?.StartData == null) return false;
+            return MutatePendingScrobble(item, d => {
+                var gameId = item.StartData.game_id;
+                var pluginId = item.StartData.plugin_id;
+                var pairedFinish = FindPairedFinish(item);
+                var laterStart = _data.PendingScrobbles.Skip(_data.PendingScrobbles.IndexOf(item) + 1)
+                    .Any(p => p.Type == "start" && IsSameGame(p, gameId, pluginId));
+                if (pairedFinish != null && string.IsNullOrEmpty(pairedFinish.FinishData.session_id)) {
+                    pairedFinish.FinishData.session_id = sessionId;
+                }
+                if (pairedFinish == null && !laterStart && !string.IsNullOrEmpty(gameId)
+                    && !string.IsNullOrEmpty(sessionId)) {
+                    _data.ActiveSessionsByGameId[gameId] = sessionId;
+                }
+                if (!laterStart && (pairedFinish != null || !string.IsNullOrEmpty(sessionId))) {
+                    _data.PendingStartGameIds.Remove(gameId);
+                }
+                _data.PendingScrobbles.Remove(item);
+                _claimedScrobbles.Remove(item);
+            });
+        }
+
+        public static bool CompletePendingScrobble(PendingScrobble item) {
+            return MutatePendingScrobble(item, d => {
+                var finish = item.FinishData;
+                if (!string.IsNullOrEmpty(finish?.game_id)
+                    && _data.ActiveSessionsByGameId.TryGetValue(finish.game_id, out var active)
+                    && active == finish.session_id) {
+                    _data.ActiveSessionsByGameId.Remove(finish.game_id);
+                }
+                _data.PendingScrobbles.Remove(item);
+                _claimedScrobbles.Remove(item);
+            });
+        }
+
+        public static bool DropPendingScrobble(PendingScrobble item) {
+            return MutatePendingScrobble(item, d => {
+                if (item.Type == "start" && item.StartData != null) {
+                    var pairedFinish = FindPairedFinish(item);
+                    if (pairedFinish != null) {
+                        _data.PendingScrobbles.Remove(pairedFinish);
+                        _claimedScrobbles.Remove(pairedFinish);
+                        _data.DroppedScrobbleCount++;
+                    }
+                    if (!_data.PendingScrobbles.Any(p => p != item && p.Type == "start"
+                        && IsSameGame(p, item.StartData.game_id, item.StartData.plugin_id))) {
+                        _data.PendingStartGameIds.Remove(item.StartData.game_id);
+                    }
+                }
+                _data.PendingScrobbles.Remove(item);
+                _claimedScrobbles.Remove(item);
+                _data.DroppedScrobbleCount++;
+            });
         }
 
         /// <summary>
@@ -628,6 +840,7 @@ namespace GsPlugin.Models {
         public static void RemovePendingScrobble(PendingScrobble item) {
             lock (_lock) {
                 _data.PendingScrobbles.Remove(item);
+                _claimedScrobbles.Remove(item);
                 SaveInternal();
             }
             DiagnosticsStateChanged?.Invoke(null, EventArgs.Empty);

--- a/Models/GsData.cs
+++ b/Models/GsData.cs
@@ -767,10 +767,10 @@ namespace GsPlugin.Models {
         }
 
         // A second start belongs to another launch: never attach its finish to this start.
-        private static PendingScrobble FindPairedFinish(PendingScrobble start) {
-            var startIndex = _data.PendingScrobbles.IndexOf(start);
-            for (var i = startIndex + 1; i < _data.PendingScrobbles.Count; i++) {
-                var candidate = _data.PendingScrobbles[i];
+        private static PendingScrobble FindPairedFinish(GsData d, PendingScrobble start) {
+            var startIndex = d.PendingScrobbles.IndexOf(start);
+            for (var i = startIndex + 1; i < d.PendingScrobbles.Count; i++) {
+                var candidate = d.PendingScrobbles[i];
                 if (!IsSameGame(candidate, start.StartData.game_id, start.StartData.plugin_id)) continue;
                 return candidate.Type == "finish" ? candidate : null;
             }
@@ -782,20 +782,20 @@ namespace GsPlugin.Models {
             return MutatePendingScrobble(item, d => {
                 var gameId = item.StartData.game_id;
                 var pluginId = item.StartData.plugin_id;
-                var pairedFinish = FindPairedFinish(item);
-                var laterStart = _data.PendingScrobbles.Skip(_data.PendingScrobbles.IndexOf(item) + 1)
+                var pairedFinish = FindPairedFinish(d, item);
+                var laterStart = d.PendingScrobbles.Skip(d.PendingScrobbles.IndexOf(item) + 1)
                     .Any(p => p.Type == "start" && IsSameGame(p, gameId, pluginId));
                 if (pairedFinish != null && string.IsNullOrEmpty(pairedFinish.FinishData.session_id)) {
                     pairedFinish.FinishData.session_id = sessionId;
                 }
                 if (pairedFinish == null && !laterStart && !string.IsNullOrEmpty(gameId)
                     && !string.IsNullOrEmpty(sessionId)) {
-                    _data.ActiveSessionsByGameId[gameId] = sessionId;
+                    d.ActiveSessionsByGameId[gameId] = sessionId;
                 }
                 if (!laterStart && (pairedFinish != null || !string.IsNullOrEmpty(sessionId))) {
-                    _data.PendingStartGameIds.Remove(gameId);
+                    d.PendingStartGameIds.Remove(gameId);
                 }
-                _data.PendingScrobbles.Remove(item);
+                d.PendingScrobbles.Remove(item);
                 _claimedScrobbles.Remove(item);
             });
         }
@@ -804,11 +804,11 @@ namespace GsPlugin.Models {
             return MutatePendingScrobble(item, d => {
                 var finish = item.FinishData;
                 if (!string.IsNullOrEmpty(finish?.game_id)
-                    && _data.ActiveSessionsByGameId.TryGetValue(finish.game_id, out var active)
+                    && d.ActiveSessionsByGameId.TryGetValue(finish.game_id, out var active)
                     && active == finish.session_id) {
-                    _data.ActiveSessionsByGameId.Remove(finish.game_id);
+                    d.ActiveSessionsByGameId.Remove(finish.game_id);
                 }
-                _data.PendingScrobbles.Remove(item);
+                d.PendingScrobbles.Remove(item);
                 _claimedScrobbles.Remove(item);
             });
         }
@@ -816,20 +816,20 @@ namespace GsPlugin.Models {
         public static bool DropPendingScrobble(PendingScrobble item) {
             return MutatePendingScrobble(item, d => {
                 if (item.Type == "start" && item.StartData != null) {
-                    var pairedFinish = FindPairedFinish(item);
+                    var pairedFinish = FindPairedFinish(d, item);
                     if (pairedFinish != null) {
-                        _data.PendingScrobbles.Remove(pairedFinish);
+                        d.PendingScrobbles.Remove(pairedFinish);
                         _claimedScrobbles.Remove(pairedFinish);
-                        _data.DroppedScrobbleCount++;
+                        d.DroppedScrobbleCount++;
                     }
-                    if (!_data.PendingScrobbles.Any(p => p != item && p.Type == "start"
+                    if (!d.PendingScrobbles.Any(p => p != item && p.Type == "start"
                         && IsSameGame(p, item.StartData.game_id, item.StartData.plugin_id))) {
-                        _data.PendingStartGameIds.Remove(item.StartData.game_id);
+                        d.PendingStartGameIds.Remove(item.StartData.game_id);
                     }
                 }
-                _data.PendingScrobbles.Remove(item);
+                d.PendingScrobbles.Remove(item);
                 _claimedScrobbles.Remove(item);
-                _data.DroppedScrobbleCount++;
+                d.DroppedScrobbleCount++;
             });
         }
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ Link your GameScrobbler account to connect data from other platforms (Steam, Xbo
 - Full library and achievement uploads are divided into chunks, preventing large Playnite libraries from producing oversized requests.
 - Later syncs compare compact local fingerprints and send only added, changed, or removed entries.
 - Failed chunked uploads are aborted without replacing the last known-good local baseline, so the next sync can retry safely.
+- A queued upload is confirmed before its local baseline is accepted. Failed or unconfirmed jobs retain the previous baseline for the next sync attempt.
+- Session starts and stops are saved before network requests, and shutdown saves all active sessions before waiting on the server.
+- Achievement read failures postpone the upload instead of clearing previously synced achievements.
 - Existing installations migrate their legacy local sync snapshot automatically. This migration affects only plugin state on your computer and does not delete library or achievement data.
 - Sync writes use the server-issued install token. On first startup, registration completes before the initial library sync begins.
 

--- a/Services/AchievementProviderBase.cs
+++ b/Services/AchievementProviderBase.cs
@@ -10,7 +10,7 @@ namespace GsPlugin.Services {
     /// on-disk data: addon presence, version lookup, and the "log a warning and report no
     /// data" wrapper that guards every read. Subclasses supply only the read logic.
     /// </summary>
-    public abstract class AchievementProviderBase : IAchievementProvider {
+    public abstract class AchievementProviderBase : IAchievementProvider, IReliableAchievementProvider {
         /// <summary>
         /// Id of the Playnite addon this provider reads data from.
         /// </summary>
@@ -55,7 +55,24 @@ namespace GsPlugin.Services {
 
         public abstract (int unlocked, int total)? GetCounts(Guid gameId);
 
-        public abstract List<AchievementItem> GetAchievements(Guid gameId);
+        protected abstract List<AchievementItem> ReadAchievementsCore(Guid gameId);
+
+        protected virtual string DescribeAchievementReadFailure(Exception ex) => null;
+
+        public List<AchievementItem> GetAchievements(Guid gameId) {
+            var result = ReadAchievements(gameId);
+            return result.IsAvailable && result.Achievements.Count > 0 ? result.Achievements : null;
+        }
+
+        public AchievementReadResult ReadAchievements(Guid gameId) {
+            try {
+                return AchievementReadResult.Available(ReadAchievementsCore(gameId), ProviderName);
+            }
+            catch (Exception ex) {
+                LogReadFailure("Achievement lookup", gameId, ex, DescribeAchievementReadFailure);
+                return AchievementReadResult.Unavailable(ProviderName);
+            }
+        }
 
         public string GetVersion() {
             try {

--- a/Services/GsAccountLinkingService.cs
+++ b/Services/GsAccountLinkingService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using Playnite.SDK;
@@ -66,6 +67,9 @@ namespace GsPlugin.Services {
         private static readonly ILogger _logger = LogManager.GetLogger();
         private readonly IGsApiClient _apiClient;
         private readonly IPlayniteAPI _playniteApi;
+        // Deep links and settings can both change the account. Serialize their requests so a
+        // slower response cannot reverse a newer link/unlink operation on the same install.
+        private static readonly SemaphoreSlim IdentityOperations = new SemaphoreSlim(1, 1);
 
         /// <summary>
         /// Event triggered when account linking status changes.
@@ -100,6 +104,23 @@ namespace GsPlugin.Services {
                 return LinkingResult.CreateError("Please enter a valid token", context);
             }
 
+            var expectedInstallId = GsDataManager.Data.InstallID;
+            var expectedGeneration = GsDataManager.Data.IdentityGeneration;
+            await IdentityOperations.WaitAsync();
+            try {
+                if (!IsActiveIdentity(expectedInstallId, expectedGeneration)) {
+                    return IdentityChangedResult(context);
+                }
+                return await LinkAccountCoreAsync(token, context, expectedInstallId, expectedGeneration);
+            }
+            finally {
+                IdentityOperations.Release();
+            }
+        }
+
+        private async Task<LinkingResult> LinkAccountCoreAsync(string token, LinkingContext context,
+            string expectedInstallId, int expectedGeneration) {
+
             GsLogger.Info($"Starting {context} account linking (install_id={GsDataManager.Data.InstallID}).");
             GsSentry.AddBreadcrumb(
                 message: $"Starting {context} account linking",
@@ -113,7 +134,11 @@ namespace GsPlugin.Services {
 
             try {
                 // Verify token with API
-                var response = await _apiClient.VerifyToken(token, GsDataManager.Data.InstallID);
+                var response = await _apiClient.VerifyToken(token, expectedInstallId);
+
+                if (!IsActiveIdentity(expectedInstallId, expectedGeneration)) {
+                    return IdentityChangedResult(context);
+                }
 
                 if (response == null) {
                     string errorMessage = "Network error — could not reach the server. Please check your connection and try again.";
@@ -130,7 +155,10 @@ namespace GsPlugin.Services {
                     // a failed link, clear any local link so state matches the server, and route the
                     // user to fetch a fresh token (same recovery path as an expired token).
                     if (!IsLinkedUserId(response.userId)) {
-                        GsDataManager.MutateAndSave(d => d.LinkedUserId = null);
+                        if (!GsDataManager.TryMutateIfActiveIdentity(expectedInstallId, expectedGeneration,
+                            d => d.LinkedUserId = null)) {
+                            return IdentityChangedResult(context);
+                        }
                         OnLinkingStatusChanged();
 
                         GsLogger.Error($"{context} linking did not complete: token verified but the server returned a not-linked result (install_id={GsDataManager.Data.InstallID}, userId={response.userId ?? "null"}).");
@@ -152,7 +180,10 @@ namespace GsPlugin.Services {
                         return LinkingResult.CreateError(errorMessage, context);
                     }
 
-                    GsDataManager.MutateAndSave(d => d.LinkedUserId = response.userId);
+                    if (!GsDataManager.TryMutateIfActiveIdentity(expectedInstallId, expectedGeneration,
+                        d => d.LinkedUserId = response.userId)) {
+                        return IdentityChangedResult(context);
+                    }
                     // Notify listeners of status change
                     OnLinkingStatusChanged();
 
@@ -220,8 +251,10 @@ namespace GsPlugin.Services {
         public static bool ValidateToken(string token) {
             if (string.IsNullOrWhiteSpace(token)) return false;
             if (token.Length > 512) return false;
-            // Allow alphanumeric, hyphens, underscores, dots, plus, equals, slashes (covers JWT/base64 tokens)
-            if (!Regex.IsMatch(token, @"^[a-zA-Z0-9\-_\.+=\/]+$")) return false;
+            // Allow alphanumeric, hyphens, underscores, dots, plus, equals, slashes (covers JWT/base64 tokens).
+            // Anchor with \z, not $: in .NET $ also matches immediately before a trailing newline, so
+            // a token with a trailing newline would otherwise pass and be sent to the server verbatim.
+            if (!Regex.IsMatch(token, @"^[a-zA-Z0-9\-_\.+=\/]+\z")) return false;
             return true;
         }
 
@@ -234,6 +267,16 @@ namespace GsPlugin.Services {
         internal static bool IsLinkedUserId(string userId) {
             return !string.IsNullOrWhiteSpace(userId) && userId != GsData.NotLinkedValue;
         }
+
+        private static bool IsActiveIdentity(string expectedInstallId, int expectedGeneration) {
+            var data = GsDataManager.DataOrNull;
+            return data != null && !data.OptedOut && data.InstallID == expectedInstallId
+                && data.IdentityGeneration == expectedGeneration;
+        }
+
+        private static LinkingResult IdentityChangedResult(LinkingContext context) =>
+            LinkingResult.CreateError(GsLocalization.Get("LOCGsPluginIdentityChangedDuringRequest",
+                "The installation changed or was disabled during this request. Please try again."), context);
 
         /// <summary>
         /// Checks if the user wants to proceed with relinking to a different account.
@@ -267,6 +310,9 @@ namespace GsPlugin.Services {
                     LinkingContext.ManualSettings);
             }
 
+            var expectedInstallId = GsDataManager.Data.InstallID;
+            var expectedGeneration = GsDataManager.Data.IdentityGeneration;
+
             var confirm = _playniteApi.Dialogs.ShowMessage(
                 GsLocalization.Get("LOCGsPluginDisconnectDialogBody", "Disconnect your account? Your game data will be kept on the server.\nYou can re-link anytime."),
                 GsLocalization.Get("LOCGsPluginDisconnectDialogTitle", "Disconnect Account"),
@@ -277,8 +323,26 @@ namespace GsPlugin.Services {
                 return LinkingResult.CreateError("Cancelled", LinkingContext.ManualSettings);
             }
 
+            await IdentityOperations.WaitAsync();
+            try {
+                if (!IsActiveIdentity(expectedInstallId, expectedGeneration)) {
+                    return IdentityChangedResult(LinkingContext.ManualSettings);
+                }
+                return await UnlinkAccountCoreAsync(expectedInstallId, expectedGeneration);
+            }
+            finally {
+                IdentityOperations.Release();
+            }
+        }
+
+        private async Task<LinkingResult> UnlinkAccountCoreAsync(string expectedInstallId, int expectedGeneration) {
+
             try {
                 var response = await _apiClient.UnlinkAccount();
+
+                if (!IsActiveIdentity(expectedInstallId, expectedGeneration)) {
+                    return IdentityChangedResult(LinkingContext.ManualSettings);
+                }
 
                 if (response == null) {
                     return LinkingResult.CreateError(
@@ -290,7 +354,10 @@ namespace GsPlugin.Services {
                     // Clear all identity-bound state to prevent data from bleeding
                     // across accounts after a re-link. Base set only: the install stays
                     // registered, so neither the InstallID nor its token is touched.
-                    GsDataManager.MutateAndSave(d => d.ClearIdentityBoundState(IdentityClearScope.None));
+                    if (!GsDataManager.TryMutateIfActiveIdentity(expectedInstallId, expectedGeneration,
+                        d => d.ClearIdentityBoundState(IdentityClearScope.None))) {
+                        return IdentityChangedResult(LinkingContext.ManualSettings);
+                    }
                     GsSyncHashIndex.Reset();
                     OnLinkingStatusChanged();
                     // Refresh diagnostics widgets (pending scrobble count, last-sync text)

--- a/Services/GsAchievementAggregator.cs
+++ b/Services/GsAchievementAggregator.cs
@@ -7,7 +7,7 @@ namespace GsPlugin.Services {
     /// Aggregates multiple achievement providers (e.g. SuccessStory, Playnite Achievements).
     /// For each game, returns data from the first provider that has it.
     /// </summary>
-    public class GsAchievementAggregator : IAchievementProvider {
+    public class GsAchievementAggregator : IAchievementProvider, IReliableAchievementProvider {
         private readonly List<IAchievementProvider> _providers;
 
         public GsAchievementAggregator(params IAchievementProvider[] providers) {
@@ -49,11 +49,18 @@ namespace GsPlugin.Services {
         }
 
         public List<AchievementItem> GetAchievements(Guid gameId) {
+            var result = ReadAchievements(gameId);
+            return result.IsAvailable && result.Achievements.Count > 0 ? result.Achievements : null;
+        }
+
+        public AchievementReadResult ReadAchievements(Guid gameId) {
             foreach (var p in ResolutionOrder()) {
-                var achievements = p.GetAchievements(gameId);
-                if (achievements != null) return achievements;
+                var result = AchievementReadResult.Read(p, gameId);
+                // A failed preferred provider cannot safely be replaced with a potentially
+                // older fallback snapshot. Retry the snapshot after the read recovers.
+                if (!result.IsAvailable || result.Achievements.Count > 0) return result;
             }
-            return null;
+            return AchievementReadResult.Available(null);
         }
 
         /// <summary>
@@ -61,11 +68,10 @@ namespace GsPlugin.Services {
         /// Used for diagnostic logging.
         /// </summary>
         public (List<AchievementItem> achievements, string providerName) GetAchievementsWithSource(Guid gameId) {
-            foreach (var p in ResolutionOrder()) {
-                var achievements = p.GetAchievements(gameId);
-                if (achievements != null) return (achievements, p.ProviderName);
-            }
-            return (null, null);
+            var result = ReadAchievements(gameId);
+            return result.IsAvailable && result.Achievements.Count > 0
+                ? (result.Achievements, result.ProviderName)
+                : (null, null);
         }
 
         /// <summary>

--- a/Services/GsHashUtils.cs
+++ b/Services/GsHashUtils.cs
@@ -18,7 +18,7 @@ namespace GsPlugin.Services {
         /// Both sides normalize to "yyyy-MM-ddTHH:mm:ssZ" (no fractional seconds, UTC).
         /// </summary>
         internal static string FormatDateForHash(DateTime? dt) =>
-            dt?.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ") ?? "";
+            dt?.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture) ?? "";
 
         /// <summary>
         /// Normalizes a date string persisted in a legacy fat snapshot (written with
@@ -185,7 +185,12 @@ namespace GsPlugin.Services {
             if (accounts == null || accounts.Count == 0) {
                 return "";
             }
-            var sorted = accounts.OrderBy(a => a.provider_id).ThenBy(a => a.account_id);
+            // StringComparer.Ordinal, matching every other hash recipe in this file: the default
+            // string comparer is CurrentCulture-linguistic, so a Windows locale change would reorder
+            // these and flip the hash, spuriously flagging integration accounts as changed.
+            var sorted = accounts
+                .OrderBy(a => a.provider_id, StringComparer.Ordinal)
+                .ThenBy(a => a.account_id, StringComparer.Ordinal);
             var sb = new StringBuilder();
             foreach (var a in sorted) {
                 sb.Append(a.provider_id).Append(':').Append(a.account_id).Append(';');

--- a/Services/GsPlayniteAchievementsHelper.cs
+++ b/Services/GsPlayniteAchievementsHelper.cs
@@ -61,77 +61,78 @@ namespace GsPlugin.Services {
             });
         }
 
-        public override List<AchievementItem> GetAchievements(Guid gameId) {
-            return SafeRead("Achievement lookup", gameId, DescribeReadFailure, () => {
-                if (!File.Exists(_dbPath)) return null;
+        protected override List<AchievementItem> ReadAchievementsCore(Guid gameId) {
+            if (!File.Exists(_dbPath)) return null;
 
-                using (var conn = new SQLiteConnection($"Data Source={_dbPath};Read Only=True;Pooling=True;")) {
-                    conn.Open();
-                    using (var cmd = conn.CreateCommand()) {
-                        cmd.CommandText = @"
-                            SELECT
-                                ad.DisplayName,
-                                ad.Description,
-                                ua.Unlocked,
-                                ua.UnlockTimeUtc,
-                                ad.GlobalPercentUnlocked
-                            FROM UserAchievements ua
-                            INNER JOIN AchievementDefinitions ad
-                                ON ua.AchievementDefinitionId = ad.Id
-                            INNER JOIN UserGameProgress ugp
-                                ON ua.UserGameProgressId = ugp.Id
-                            INNER JOIN Users u
-                                ON ugp.UserId = u.Id
-                            WHERE ugp.CacheKey = @playniteId
-                              AND u.IsCurrentUser = 1
-                              AND ugp.HasAchievements = 1
-                        ";
-                        cmd.Parameters.AddWithValue("@playniteId", gameId.ToString());
+            using (var conn = new SQLiteConnection($"Data Source={_dbPath};Read Only=True;Pooling=True;")) {
+                conn.Open();
+                using (var cmd = conn.CreateCommand()) {
+                    cmd.CommandText = @"
+                        SELECT
+                            ad.DisplayName,
+                            ad.Description,
+                            ua.Unlocked,
+                            ua.UnlockTimeUtc,
+                            ad.GlobalPercentUnlocked
+                        FROM UserAchievements ua
+                        INNER JOIN AchievementDefinitions ad
+                            ON ua.AchievementDefinitionId = ad.Id
+                        INNER JOIN UserGameProgress ugp
+                            ON ua.UserGameProgressId = ugp.Id
+                        INNER JOIN Users u
+                            ON ugp.UserId = u.Id
+                        WHERE ugp.CacheKey = @playniteId
+                          AND u.IsCurrentUser = 1
+                          AND ugp.HasAchievements = 1
+                    ";
+                    cmd.Parameters.AddWithValue("@playniteId", gameId.ToString());
 
-                        var result = new List<AchievementItem>();
-                        using (var reader = cmd.ExecuteReader()) {
-                            while (reader.Read()) {
-                                var displayName = reader.IsDBNull(0) ? null : reader.GetString(0);
-                                var description = reader.IsDBNull(1) ? null : reader.GetString(1);
-                                var unlocked = !reader.IsDBNull(2) && reader.GetBoolean(2);
+                    var result = new List<AchievementItem>();
+                    using (var reader = cmd.ExecuteReader()) {
+                        while (reader.Read()) {
+                            var displayName = reader.IsDBNull(0) ? null : reader.GetString(0);
+                            var description = reader.IsDBNull(1) ? null : reader.GetString(1);
+                            var unlocked = !reader.IsDBNull(2) && reader.GetBoolean(2);
 
-                                DateTime? dateUnlocked = null;
-                                if (!reader.IsDBNull(3)) {
-                                    var unlockStr = reader.GetString(3);
-                                    if (DateTime.TryParse(unlockStr, null,
-                                            System.Globalization.DateTimeStyles.RoundtripKind,
-                                            out var parsed)
-                                        && parsed > DateTime.MinValue && parsed.Year > 1) {
-                                        dateUnlocked = parsed;
-                                    }
+                            DateTime? dateUnlocked = null;
+                            if (!reader.IsDBNull(3)) {
+                                var unlockStr = reader.GetString(3);
+                                // InvariantCulture, not null: a null provider means CurrentCulture,
+                                // so an ISO timestamp read under a non-Gregorian calendar (th-TH,
+                                // ar-SA) parses to a wildly wrong year and is then uploaded.
+                                if (DateTime.TryParse(unlockStr, System.Globalization.CultureInfo.InvariantCulture,
+                                        System.Globalization.DateTimeStyles.RoundtripKind,
+                                        out var parsed)
+                                    && parsed > DateTime.MinValue && parsed.Year > 1) {
+                                    dateUnlocked = parsed;
                                 }
-
-                                float? rarityPercent = null;
-                                if (!reader.IsDBNull(4)) {
-                                    rarityPercent = (float)reader.GetDouble(4);
-                                }
-
-                                result.Add(new AchievementItem {
-                                    Name = displayName,
-                                    Description = description,
-                                    DateUnlocked = unlocked ? dateUnlocked : null,
-                                    IsUnlocked = unlocked,
-                                    RarityPercent = rarityPercent
-                                });
                             }
-                        }
 
-                        return result.Count > 0 ? result : null;
+                            float? rarityPercent = null;
+                            if (!reader.IsDBNull(4)) {
+                                rarityPercent = (float)reader.GetDouble(4);
+                            }
+
+                            result.Add(new AchievementItem {
+                                Name = displayName,
+                                Description = description,
+                                DateUnlocked = unlocked ? dateUnlocked : null,
+                                IsUnlocked = unlocked,
+                                RarityPercent = rarityPercent
+                            });
+                        }
                     }
+
+                    return result.Count > 0 ? result : null;
                 }
-            });
+            }
         }
 
         /// <summary>
         /// Wording for the failure types these database reads distinguish; null means the
         /// generic "{operation} failed" message applies.
         /// </summary>
-        private static string DescribeReadFailure(Exception ex) {
+        protected override string DescribeAchievementReadFailure(Exception ex) {
             if (ex is SQLiteException) return "SQLite error";
             if (ex is IOException) return "DB file access error";
             return null;

--- a/Services/GsScrobblingService.cs
+++ b/Services/GsScrobblingService.cs
@@ -486,9 +486,21 @@ namespace GsPlugin.Services {
                 if (commit == null || !commit.success) {
                     // A commit that never resolved (null transport failure) or that the server
                     // rejected leaves the session open; abort so the next attempt can begin anew.
-                    _logger.Error($"{label} v4 commit failed: status={commit?.status}");
+                    //
+                    // force-full-sync is a business outcome, not a failure: the server answers a
+                    // snapshot-hash mismatch with success=false and a reason the caller acts on.
+                    // Collapsing it to null here would keep the caller's recovery branch unreachable
+                    // even though the body now survives the HTTP layer, so propagate it. The session
+                    // is still aborted either way -- nothing was committed.
+                    var isForceFullSync = commit != null && commit.status == "force-full-sync";
+                    if (isForceFullSync) {
+                        _logger.Warn($"{label} v4 commit rejected: force-full-sync (reason: {commit.reason})");
+                    }
+                    else {
+                        _logger.Error($"{label} v4 commit failed: status={commit?.status}");
+                    }
                     await abortAsync(syncId);
-                    return null;
+                    return isForceFullSync ? commit : null;
                 }
                 return commit;
             }
@@ -557,24 +569,23 @@ namespace GsPlugin.Services {
         }
 
         /// <summary>Polling cadence for <see cref="TryConfirmQueueCompletionAsync"/>.</summary>
-        private static readonly TimeSpan QueueStatusPollInterval = TimeSpan.FromSeconds(1.5);
+        internal TimeSpan QueueStatusPollInterval { get; set; } = TimeSpan.FromSeconds(1.5);
 
         /// <summary>
         /// Total time budget for <see cref="TryConfirmQueueCompletionAsync"/>. Matches the server's
         /// documented "1-5 seconds" typical processing time with margin, so a poll never meaningfully
         /// delays startup/library-updated callbacks that await these sync methods.
         /// </summary>
-        private static readonly TimeSpan QueueStatusPollBudget = TimeSpan.FromSeconds(8);
+        internal TimeSpan QueueStatusPollBudget { get; set; } = TimeSpan.FromSeconds(8);
 
         /// <summary>
         /// Best-effort check of a queued sync job's terminal status via GET /queue/status/:queueId.
         /// A "queued" admission only means the request was accepted onto the async queue, not that
         /// the server applied it — see gs-playnite#83, where a job that failed after admission left
         /// the client believing it had synced. Bounded to a short budget: if the job hasn't reached a
-        /// terminal state in time (large library, slow backend), returns null so the caller falls back
-        /// to the pre-existing behavior of trusting the "queued" admission. This only tightens the
-        /// common case — a job that fails fast (validation error, immediate crash) is now caught
-        /// instead of silently treated as success.
+        /// terminal state in time (large library, slow backend), returns null and leaves the
+        /// previous baseline intact. The next sync can retry or recover through force-full-sync;
+        /// an admission without confirmed completion must never suppress that retry.
         /// </summary>
         /// <returns>true if the job completed successfully, false if it failed/partially applied,
         /// or null if no terminal status was observed within the budget.</returns>
@@ -610,8 +621,8 @@ namespace GsPlugin.Services {
                 }
             } while (DateTime.UtcNow < deadline);
 
-            _logger.Info($"{label}: job {queueId} still processing after {QueueStatusPollBudget.TotalSeconds:F0}s — " +
-                "committing baseline optimistically (server may still be working on a large library).");
+            _logger.Info($"{label}: no confirmed completion for job {queueId} after {QueueStatusPollBudget.TotalSeconds:F0}s — " +
+                "keeping the previous baseline so a later sync can retry.");
             return null;
         }
 
@@ -665,10 +676,12 @@ namespace GsPlugin.Services {
         private async Task<SyncLibraryResult> CommitSyncBaselineAsync(
             string label,
             string queueId,
+            string expectedInstallId,
+            int expectedGeneration,
             Func<bool> persistIndex,
             Action<GsData> persistHashes,
             string queuedDetail = null) {
-            if (await TryConfirmQueueCompletionAsync(label, queueId) == false) {
+            if (await TryConfirmQueueCompletionAsync(label, queueId) != true) {
                 return SyncLibraryResult.Error;
             }
 
@@ -676,13 +689,18 @@ namespace GsPlugin.Services {
                 ? $"{label} queued successfully."
                 : $"{label} queued successfully ({queuedDetail}).");
 
-            if (!persistIndex()) {
+            var indexSaved = false;
+            // The data lock also fences the index write. Index stores read DataOrNull
+            // without taking this lock, so this does not invert their lock order.
+            var saved = GsDataManager.TryMutateIfActiveIdentity(expectedInstallId, expectedGeneration, d => {
+                indexSaved = persistIndex();
+                if (indexSaved) persistHashes(d);
+            });
+            if (!saved || !indexSaved) {
                 _logger.Error($"{label} queued but local hash index save failed — " +
-                    "not committing hash baseline. Will retry next run.");
+                    "or the installation changed; will retry next run.");
                 return SyncLibraryResult.Error;
             }
-
-            GsDataManager.MutateAndSave(persistHashes);
             return SyncLibraryResult.Success;
         }
 
@@ -695,6 +713,8 @@ namespace GsPlugin.Services {
             IEnumerable<Playnite.SDK.Models.Game> playniteDatabaseGames, bool bypassCooldown = false) {
             try {
                 if (GsDataManager.IsOptedOut) return SyncLibraryResult.Skipped;
+                var installId = GsDataManager.Data.InstallID;
+                var generation = GsDataManager.Data.IdentityGeneration;
 
                 if (!bypassCooldown) {
                     var cooldownExpiry = GsDataManager.Data.SyncCooldownExpiresAt;
@@ -707,6 +727,7 @@ namespace GsPlugin.Services {
                 _logger.Info("Starting full library sync (v4 chunked)");
                 var (library, libraryHash, totalCount, _) = await BuildLibraryDtosAsync(playniteDatabaseGames);
 
+                if (!IsCurrentIdentity(installId, generation)) return SyncLibraryResult.Error;
                 var integrationAccounts = ReadIntegrationAccountsSafe();
                 var accountsHash = GsHashUtils.ComputeIntegrationAccountsHash(integrationAccounts);
                 var accountsChanged = accountsHash != (GsDataManager.Data.LastIntegrationAccountsHash ?? "");
@@ -723,6 +744,7 @@ namespace GsPlugin.Services {
 
                 var response = await UploadLibraryFullChunkedAsync(library, libraryHash, integrationAccounts);
 
+                if (!IsCurrentIdentity(installId, generation)) return SyncLibraryResult.Error;
                 if (response == null) {
                     _logger.Error("Failed to queue full library sync.");
                     return SyncLibraryResult.Error;
@@ -742,7 +764,7 @@ namespace GsPlugin.Services {
                     var libCount = library.Count;
                     return await CommitSyncBaselineAsync(
                         "Full library sync",
-                        response.queueId,
+                        response.queueId, installId, generation,
                         () => GsSyncHashIndex.ReplaceLibraryIndex(BuildLibraryFingerprints(library)),
                         d => {
                             d.LastSyncAt = DateTime.UtcNow;
@@ -829,6 +851,8 @@ namespace GsPlugin.Services {
             IEnumerable<Playnite.SDK.Models.Game> playniteDatabaseGames) {
             try {
                 if (GsDataManager.IsOptedOut) return SyncLibraryResult.Skipped;
+                var installId = GsDataManager.Data.InstallID;
+                var generation = GsDataManager.Data.IdentityGeneration;
 
                 var cooldownExpiry = GsDataManager.Data.LibraryDiffSyncCooldownExpiresAt;
                 if (cooldownExpiry.HasValue && DateTime.UtcNow < cooldownExpiry.Value) {
@@ -839,6 +863,7 @@ namespace GsPlugin.Services {
                 _logger.Info("Starting diff library sync (v2)");
                 var (library, libraryHash, totalCount, _) = await BuildLibraryDtosAsync(playniteDatabaseGames);
 
+                if (!IsCurrentIdentity(installId, generation)) return SyncLibraryResult.Error;
                 var integrationAccounts = ReadIntegrationAccountsSafe();
                 var accountsHash = GsHashUtils.ComputeIntegrationAccountsHash(integrationAccounts);
                 var accountsChanged = accountsHash != (GsDataManager.Data.LastIntegrationAccountsHash ?? "");
@@ -855,6 +880,7 @@ namespace GsPlugin.Services {
                 var (added, updated, removed, currentFingerprints) = await Task.Run(() =>
                     ComputeLibraryDiff(library, fingerprints));
 
+                if (!IsCurrentIdentity(installId, generation)) return SyncLibraryResult.Error;
                 // If only integration accounts changed (no library diff), still send the request
                 // with empty diff so the backend can process the new accounts.
                 if (added.Count == 0 && updated.Count == 0 && removed.Count == 0 && !accountsChanged) {
@@ -882,6 +908,7 @@ namespace GsPlugin.Services {
                     integration_accounts = integrationAccounts.Count > 0 ? integrationAccounts : null
                 });
 
+                if (!IsCurrentIdentity(installId, generation)) return SyncLibraryResult.Error;
                 if (response == null) {
                     _logger.Error("Failed to queue library diff sync.");
                     return SyncLibraryResult.Error;
@@ -907,7 +934,7 @@ namespace GsPlugin.Services {
                     var libCount = library.Count;
                     return await CommitSyncBaselineAsync(
                         "Library diff sync",
-                        response.queueId,
+                        response.queueId, installId, generation,
                         () => GsSyncHashIndex.ApplyLibraryDiff(
                             added.Concat(updated).ToDictionary(
                                 g => g.playnite_id,
@@ -941,6 +968,8 @@ namespace GsPlugin.Services {
             IEnumerable<Playnite.SDK.Models.Game> playniteDatabaseGames, bool bypassCooldown = false) {
             try {
                 if (GsDataManager.IsOptedOut) return SyncLibraryResult.Skipped;
+                var installId = GsDataManager.Data.InstallID;
+                var generation = GsDataManager.Data.IdentityGeneration;
 
                 if (!GsDataManager.Data.SyncAchievements || !_achievementHelper.IsInstalled) {
                     _logger.Info("Achievement sync skipped: disabled or no achievement provider installed.");
@@ -960,7 +989,7 @@ namespace GsPlugin.Services {
                     return allGames
                         .Where(GsAllowedPlugins.IsAllowed)
                         .Select(g => {
-                            var achievements = _achievementHelper.GetAchievements(g.Id);
+                            var achievements = ReadAchievementsForSync(g.Id).Achievements;
                             if (achievements == null || achievements.Count == 0)
                                 return null;
 
@@ -991,17 +1020,8 @@ namespace GsPlugin.Services {
                         .ToList();
                 });
 
+                if (!IsCurrentIdentity(installId, generation)) return SyncLibraryResult.Error;
                 var achHash = GsHashUtils.ComputeAchievementHash(games);
-
-                if (games.Count == 0) {
-                    _logger.Info("No games with achievements found — setting empty baseline.");
-                    if (!GsSyncHashIndex.ReplaceAchievementIndex(new Dictionary<string, string>())) {
-                        _logger.Error("Failed to persist empty achievements baseline.");
-                        return SyncLibraryResult.Error;
-                    }
-                    GsDataManager.MutateAndSave(d => d.LastAchievementHash = achHash);
-                    return SyncLibraryResult.Skipped;
-                }
 
                 if (achHash == GsDataManager.Data.LastAchievementHash && GsSyncHashIndex.HasAchievementsBaseline) {
                     return SkipOrRepairIndex(
@@ -1017,6 +1037,7 @@ namespace GsPlugin.Services {
 
                 var response = await UploadAchievementsFullChunkedAsync(games, achHash);
 
+                if (!IsCurrentIdentity(installId, generation)) return SyncLibraryResult.Error;
                 if (response == null) {
                     _logger.Error("Failed to queue full achievements sync.");
                     return SyncLibraryResult.Error;
@@ -1030,12 +1051,16 @@ namespace GsPlugin.Services {
                 if (response.success && response.status == "queued") {
                     return await CommitSyncBaselineAsync(
                         "Full achievements sync",
-                        response.queueId,
+                        response.queueId, installId, generation,
                         () => GsSyncHashIndex.ReplaceAchievementIndex(BuildAchievementFingerprints(games)),
                         d => d.LastAchievementHash = achHash);
                 }
 
                 _logger.Error($"Unexpected response from full achievements sync: status={response.status}");
+                return SyncLibraryResult.Error;
+            }
+            catch (AchievementReadUnavailableException ex) {
+                _logger.Warn(ex.Message);
                 return SyncLibraryResult.Error;
             }
             catch (Exception ex) {
@@ -1053,6 +1078,8 @@ namespace GsPlugin.Services {
             IEnumerable<Playnite.SDK.Models.Game> playniteDatabaseGames) {
             try {
                 if (GsDataManager.IsOptedOut) return SyncLibraryResult.Skipped;
+                var installId = GsDataManager.Data.InstallID;
+                var generation = GsDataManager.Data.IdentityGeneration;
 
                 if (!GsDataManager.Data.SyncAchievements || !_achievementHelper.IsInstalled) {
                     _logger.Info("Achievement diff sync skipped: disabled or no achievement provider installed.");
@@ -1106,17 +1133,9 @@ namespace GsPlugin.Services {
 
                         filteredCount++;
                         var playniteId = g.Id.ToString();
-                        List<AchievementItem> achievements;
-                        string sourceProvider = null;
-
-                        if (_achievementHelper is GsAchievementAggregator diagAgg) {
-                            var (achs, src) = diagAgg.GetAchievementsWithSource(g.Id);
-                            achievements = achs;
-                            sourceProvider = src;
-                        }
-                        else {
-                            achievements = _achievementHelper.GetAchievements(g.Id);
-                        }
+                        var read = ReadAchievementsForSync(g.Id);
+                        var achievements = read.Achievements;
+                        var sourceProvider = read.ProviderName;
 
                         if (achievements == null || achievements.Count == 0) {
                             nullCount++;
@@ -1193,6 +1212,7 @@ namespace GsPlugin.Services {
                     return (result, cleared, live, changedFps);
                 });
 
+                if (!IsCurrentIdentity(installId, generation)) return SyncLibraryResult.Error;
                 if (changed.Count == 0 && clearedIds.Count == 0) {
                     _logger.Info("Achievement diff is empty — skipping.");
                     return SyncLibraryResult.Skipped;
@@ -1226,6 +1246,7 @@ namespace GsPlugin.Services {
                     result_snapshot_hash = resultAchievementHash
                 });
 
+                if (!IsCurrentIdentity(installId, generation)) return SyncLibraryResult.Error;
                 if (response == null) {
                     _logger.Error("Failed to queue achievements diff sync.");
                     return SyncLibraryResult.Error;
@@ -1241,12 +1262,16 @@ namespace GsPlugin.Services {
                 if (response.success && response.status == "queued") {
                     return await CommitSyncBaselineAsync(
                         "Achievement diff sync",
-                        response.queueId,
+                        response.queueId, installId, generation,
                         () => GsSyncHashIndex.ApplyAchievementDiff(upsertedFingerprints, allCleared),
                         d => d.LastAchievementHash = resultAchievementHash);
                 }
 
                 _logger.Error($"Unexpected response from achievements diff sync: status={response.status}");
+                return SyncLibraryResult.Error;
+            }
+            catch (AchievementReadUnavailableException ex) {
+                _logger.Warn(ex.Message);
                 return SyncLibraryResult.Error;
             }
             catch (Exception ex) {

--- a/Services/GsScrobblingService.cs
+++ b/Services/GsScrobblingService.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Playnite.SDK;
 using Playnite.SDK.Events;
@@ -20,6 +23,23 @@ namespace GsPlugin.Services {
         private readonly IGsApiClient _apiClient;
         private readonly IAchievementProvider _achievementHelper;
         private readonly GsIntegrationAccountReader _integrationAccountReader;
+        private readonly ConcurrentDictionary<string, SemaphoreSlim> _sessionGates =
+            new ConcurrentDictionary<string, SemaphoreSlim>();
+        private readonly ConcurrentDictionary<string, Playnite.SDK.Models.Game> _runningGames =
+            new ConcurrentDictionary<string, Playnite.SDK.Models.Game>();
+
+        private sealed class AchievementReadUnavailableException : Exception {
+            public AchievementReadUnavailableException(string providerName, Guid gameId)
+                : base($"Achievement snapshot unavailable from {providerName ?? "provider"} for {gameId}; keeping the previous baseline.") { }
+        }
+
+        private AchievementReadResult ReadAchievementsForSync(Guid gameId) {
+            var result = AchievementReadResult.Read(_achievementHelper, gameId);
+            if (!result.IsAvailable) {
+                throw new AchievementReadUnavailableException(result.ProviderName, gameId);
+            }
+            return result;
+        }
 
         /// <summary>
         /// Initializes a new instance of the GsScrobblingService.
@@ -34,37 +54,21 @@ namespace GsPlugin.Services {
         }
 
         /// <summary>
-        /// Clears the active session ID for a specific game. Playnite allows multiple
-        /// games to run simultaneously, so sessions are tracked per game ID.
-        /// </summary>
-        private static void ClearActiveSession(string gameId) {
-            if (string.IsNullOrEmpty(gameId)) return;
-            if (GsDataManager.HasActiveSession(gameId)) {
-                _logger.Info($"Clearing active session ID for game ID: {gameId}");
-                GsDataManager.MutateAndSave(d => d.ActiveSessionsByGameId.Remove(gameId));
-            }
-        }
-
-        /// <summary>
-        /// Sets the active session ID for a specific game and persists it to storage.
-        /// </summary>
-        /// <param name="gameId">The Playnite game ID the session belongs to.</param>
-        /// <param name="sessionId">The session ID to set as active.</param>
-        private static void SetActiveSession(string gameId, string sessionId) {
-            if (string.IsNullOrEmpty(gameId) || string.IsNullOrEmpty(sessionId)) {
-                _logger.Warn("Attempted to set active session with empty or null game ID or session ID");
-                return;
-            }
-
-            _logger.Info($"Setting active session ID for game ID {gameId}: {sessionId}");
-            GsDataManager.MutateAndSave(d => d.ActiveSessionsByGameId[gameId] = sessionId);
-        }
-
-        /// <summary>
         /// The scrobble timestamp format. Local time (not UTC) on purpose: the server
         /// stores the offset carried by "K" and reports sessions in the player's own clock.
         /// </summary>
         private const string ScrobbleTimestampFormat = "yyyy-MM-ddTHH:mm:ssK";
+
+        /// <summary>
+        /// Renders a scrobble timestamp in <see cref="ScrobbleTimestampFormat"/>, always with
+        /// <see cref="CultureInfo.InvariantCulture"/>. In a custom format string "-" and ":" are the
+        /// culture's date/time separator specifiers and "yyyy" renders through the culture's calendar,
+        /// so under th-TH (ThaiBuddhist) the year would serialize as 2569 and under fi-FI the time as
+        /// "14.47.53" - values the server cannot parse. Call sites must go through this helper rather
+        /// than formatting inline, so a new one cannot silently reintroduce the bug.
+        /// </summary>
+        internal static string FormatScrobbleTimestamp(DateTime at) =>
+            at.ToString(ScrobbleTimestampFormat, CultureInfo.InvariantCulture);
 
         /// <summary>
         /// Builds the session-start payload for a Playnite game. Shared by the live send and the
@@ -80,7 +84,7 @@ namespace GsPlugin.Services {
                 external_game_id = g.GameId,
                 source_name = g.Source?.Name,
                 metadata = new { PluginId = g.PluginId.ToString(), SourceName = g.Source?.Name },
-                started_at = at.ToString(ScrobbleTimestampFormat)
+                started_at = FormatScrobbleTimestamp(at)
             };
         }
 
@@ -99,151 +103,133 @@ namespace GsPlugin.Services {
                 source_name = g.Source?.Name,
                 session_id = sessionId,
                 metadata = new { PluginId = g.PluginId.ToString(), SourceName = g.Source?.Name },
-                finished_at = at.ToString(ScrobbleTimestampFormat)
+                finished_at = FormatScrobbleTimestamp(at)
             };
         }
 
-        /// <summary>
-        /// Handles the game starting event and initiates a new scrobbling session.
-        /// </summary>
-        /// <param name="args">Event arguments containing game information.</param>
+        private static bool IsCurrentIdentity(string installId, int generation) =>
+            !GsDataManager.IsOptedOut && GsDataManager.Data.InstallID == installId
+            && GsDataManager.Data.IdentityGeneration == generation;
+
+        /// <summary>Persists the start before attempting its live send.</summary>
         public async Task OnGameStartAsync(OnGameStartingEventArgs args) {
+            var at = DateTime.Now;
+            PendingScrobble pending = null;
+            SemaphoreSlim gate = null;
+            var enteredGate = false;
             try {
-                if (GsDataManager.IsOptedOut) return;
+                if (GsDataManager.IsOptedOut || GsDataManager.Data.Flags.Contains("no-scrobble")
+                    || args?.Game == null || !GsAllowedPlugins.IsAllowed(args.Game)) return;
 
-                // Skip scrobbling if disabled
-                if (GsDataManager.Data.Flags.Contains("no-scrobble")) {
-                    _logger.Info("Scrobbling disabled, skipping game start tracking");
-                    return;
-                }
+                var game = args.Game;
+                var gameId = game.Id.ToString();
+                var installId = GsDataManager.Data.InstallID;
+                var generation = GsDataManager.Data.IdentityGeneration;
+                pending = new PendingScrobble {
+                    Type = "start",
+                    StartData = BuildStartReq(game, at),
+                    QueuedAt = at
+                };
+                GsDataManager.ClaimPendingScrobble(pending);
+                // Persist the event before any await. Claims prevent the background flusher
+                // from sending this same item while the live handler owns it.
+                if (!GsDataManager.TryMutateIfActiveIdentity(installId, generation, d => {
+                    d.PendingScrobbles.Add(pending);
+                    if (!d.PendingStartGameIds.Contains(gameId)) d.PendingStartGameIds.Add(gameId);
+                })) return;
+                _runningGames[gameId] = game;
 
-                if (args?.Game == null) {
-                    _logger.Warn("OnGameStartAsync called with null game; skipping.");
-                    return;
-                }
+                gate = _sessionGates.GetOrAdd(gameId, _ => new SemaphoreSlim(1, 1));
+                await gate.WaitAsync();
+                enteredGate = true;
+                if (!IsCurrentIdentity(installId, generation)) return;
+                if (GsDataManager.HasEarlierPendingScrobble(pending)) return;
 
-                DateTime localDate = DateTime.Now;
-                var startedGame = args.Game;
-
-                // Skip scrobbling for unsupported plugins
-                if (!GsAllowedPlugins.IsAllowed(startedGame)) {
-                    _logger.Info($"Skipping scrobble start for unsupported plugin: {startedGame.PluginId}");
-                    return;
-                }
-
-                _logger.Info($"Starting scrobble session for game: {startedGame.Name} (ID: {startedGame.Id})");
-
-                // Re-check opt-out before sending data (user may have opted out mid-flight)
-                if (GsDataManager.IsOptedOut) return;
-
-                var sessionData = await _apiClient.StartGameSession(BuildStartReq(startedGame, localDate));
-                var startedGameId = startedGame.Id.ToString();
-
-                if (sessionData != null && !string.IsNullOrEmpty(sessionData.session_id)) {
-                    SetActiveSession(startedGameId, sessionData.session_id);
-                    // Clear any stale pending-start marker for this game so the stop handler
-                    // uses the normal active-session path instead of the queued-pair branch.
-                    if (GsDataManager.HasPendingStart(startedGameId)) {
-                        GsDataManager.MutateAndSave(d => d.PendingStartGameIds.Remove(startedGameId));
-                    }
-                    _logger.Info($"Successfully started scrobble session with ID: {sessionData.session_id}");
+                var response = await _apiClient.StartGameSession(pending.StartData);
+                if (response != null) {
+                    // Atomically associate an already-queued stop with the returned session,
+                    // or record an active session if this game has not stopped yet.
+                    GsDataManager.CompletePendingStart(pending, response.session_id);
                 }
                 else {
-                    _logger.Error($"Failed to start scrobble session for game: {startedGame.Name} (ID: {startedGame.Id}). Queuing start for retry.");
-                    GsDataManager.EnqueuePendingScrobble(new PendingScrobble {
-                        Type = "start",
-                        StartData = BuildStartReq(startedGame, localDate),
-                        QueuedAt = localDate
-                    });
-                    // Mark that this game has a queued start so OnGameStoppedAsync can pair it
-                    // with a finish even though there is no active session for it.
-                    if (!GsDataManager.HasPendingStart(startedGameId)) {
-                        GsDataManager.MutateAndSave(d => d.PendingStartGameIds.Add(startedGameId));
-                    }
+                    _logger.Warn($"Start for game {gameId} remains queued for retry.");
                 }
             }
             catch (Exception ex) {
-                _logger.Error(ex, $"Error starting scrobble session for game: {args?.Game?.Name ?? "<null>"} (ID: {(args?.Game != null ? args.Game.Id.ToString() : "<null>")})");
+                _logger.Error(ex, "Error starting scrobble session; any persisted event remains queued.");
+            }
+            finally {
+                if (enteredGate) gate.Release();
+                if (pending != null) GsDataManager.ReleasePendingScrobble(pending);
             }
         }
 
         /// <summary>
-        /// Handles the game stopped event and finishes the active scrobbling session.
+        /// Captures and persists the stop timestamp immediately, then waits for an earlier
+        /// start of this game to resolve. A slow start cannot discard a short session's stop.
         /// </summary>
-        /// <param name="args">Event arguments containing game information.</param>
         public async Task OnGameStoppedAsync(OnGameStoppedEventArgs args) {
+            var at = DateTime.Now;
+            PendingScrobble pending = null;
+            SemaphoreSlim gate = null;
+            var enteredGate = false;
             try {
-                if (GsDataManager.IsOptedOut) return;
+                if (GsDataManager.IsOptedOut || GsDataManager.Data.Flags.Contains("no-scrobble")
+                    || args?.Game == null || !GsAllowedPlugins.IsAllowed(args.Game)) return;
 
-                if (GsDataManager.Data.Flags.Contains("no-scrobble")) {
-                    _logger.Info("Scrobbling disabled, skipping game stop tracking");
-                    return;
-                }
-                if (args?.Game == null) {
-                    _logger.Warn("OnGameStoppedAsync called with null game; skipping.");
-                    return;
-                }
+                var game = args.Game;
+                var gameId = game.Id.ToString();
+                var installId = GsDataManager.Data.InstallID;
+                var generation = GsDataManager.Data.IdentityGeneration;
+                var startPending = GsDataManager.HasPendingStart(gameId);
+                GsDataManager.TryGetActiveSession(gameId, out var sessionId);
+                if (!startPending && string.IsNullOrEmpty(sessionId)) return;
 
-                DateTime localDate = DateTime.Now;
-                var stoppedGame = args.Game;
-                var stoppedGameId = stoppedGame.Id.ToString();
+                pending = new PendingScrobble {
+                    Type = "finish",
+                    FinishData = BuildFinishReq(game, startPending ? null : sessionId, at),
+                    QueuedAt = at
+                };
+                GsDataManager.ClaimPendingScrobble(pending);
+                if (!GsDataManager.TryMutateIfActiveIdentity(installId, generation, d => {
+                    // The start may have completed between the initial snapshot and this
+                    // transaction. Resolve its session here before appending the stop.
+                    if (string.IsNullOrEmpty(pending.FinishData.session_id)
+                        && !d.PendingScrobbles.Any(item => item.Type == "start" && item.StartData?.game_id == gameId)
+                        && d.ActiveSessionsByGameId.TryGetValue(gameId, out var completedSession)) {
+                        pending.FinishData.session_id = completedSession;
+                    }
+                    d.PendingScrobbles.Add(pending);
+                    d.PendingStartGameIds.Remove(gameId);
+                    // The durable finish owns completion from now on. Never erase a newer
+                    // session merely because it uses the same Playnite game ID.
+                    if (!string.IsNullOrEmpty(pending.FinishData.session_id)
+                        && d.ActiveSessionsByGameId.TryGetValue(gameId, out var current) && current == pending.FinishData.session_id) {
+                        d.ActiveSessionsByGameId.Remove(gameId);
+                    }
+                })) return;
+                _runningGames.TryRemove(gameId, out _);
 
-                // If the start was queued (failed to send), queue a matching finish so the
-                // replay produces a paired session. No API call is needed here.
-                if (GsDataManager.HasPendingStart(stoppedGameId)) {
-                    _logger.Info($"Queuing finish to pair with pending start for game: {stoppedGame.Name} (ID: {stoppedGame.Id})");
-                    GsDataManager.EnqueuePendingScrobble(new PendingScrobble {
-                        Type = "finish",
-                        FinishData = BuildFinishReq(stoppedGame, null, localDate),
-                        QueuedAt = localDate
-                    });
-                    GsDataManager.MutateAndSave(d => d.PendingStartGameIds.Remove(stoppedGameId));
-                    return;
-                }
+                gate = _sessionGates.GetOrAdd(gameId, _ => new SemaphoreSlim(1, 1));
+                await gate.WaitAsync();
+                enteredGate = true;
+                if (!IsCurrentIdentity(installId, generation)) return;
+                if (GsDataManager.HasEarlierPendingScrobble(pending)) return;
+                // A failed start is still ahead of this finish in the durable queue. Replay
+                // must resolve it first; sending the finish now could finish an older session.
+                if (string.IsNullOrEmpty(pending.FinishData.session_id)) return;
 
-                // Capture the session ID for this game once, up front — re-reading shared
-                // state after the awaited network call below could observe a different
-                // game's session if OnGameStartAsync ran concurrently in the interim.
-                if (!GsDataManager.TryGetActiveSession(stoppedGameId, out var activeSessionId) || string.IsNullOrEmpty(activeSessionId)) {
-                    _logger.Warn($"No active session ID found when stopping game: {stoppedGame.Name} (ID: {stoppedGame.Id})");
-                    return;
-                }
-
-                // Skip scrobbling for unsupported plugins
-                if (!GsAllowedPlugins.IsAllowed(stoppedGame)) {
-                    _logger.Info($"Skipping scrobble finish for unsupported plugin: {stoppedGame.PluginId}");
-                    // Still clear the active session since we may have tracked start before this filter existed
-                    ClearActiveSession(stoppedGameId);
-                    return;
-                }
-
-                _logger.Info($"Stopping scrobble session for game: {stoppedGame.Name} (ID: {stoppedGame.Id})");
-
-                // Re-check opt-out before sending data (user may have opted out mid-flight)
-                if (GsDataManager.IsOptedOut) return;
-
-                var finishResponse = await _apiClient.FinishGameSession(
-                    BuildFinishReq(stoppedGame, activeSessionId, localDate));
-                if (finishResponse != null) {
-                    // Only clear the session ID if the request was successful
-                    ClearActiveSession(stoppedGameId);
-                    _logger.Info($"Successfully finished scrobble session for game: {stoppedGame.Name} (ID: {stoppedGame.Id})");
-                }
-                else {
-                    _logger.Error($"Failed to finish game session for {stoppedGame.Name} (ID: {stoppedGame.Id}). Queuing for retry.");
-                    GsDataManager.EnqueuePendingScrobble(new PendingScrobble {
-                        Type = "finish",
-                        FinishData = BuildFinishReq(stoppedGame, activeSessionId, localDate),
-                        QueuedAt = localDate
-                    });
-                    // Leave this game's active session entry in place so a manual retry still has the session ID
-                }
+                var response = await _apiClient.FinishGameSession(pending.FinishData);
+                if (response != null) GsDataManager.CompletePendingScrobble(pending);
             }
             catch (Exception ex) {
-                _logger.Error(ex, $"Error stopping scrobble session for game: {args?.Game?.Name ?? "<null>"} (ID: {(args?.Game != null ? args.Game.Id.ToString() : "<null>")})");
+                _logger.Error(ex, "Error stopping scrobble session; any persisted event remains queued.");
+            }
+            finally {
+                if (enteredGate) gate.Release();
+                if (pending != null) GsDataManager.ReleasePendingScrobble(pending);
             }
         }
-
         /// <summary>
         /// Handles the application stopped event and cleans up any active scrobbling session(s).
         /// This ensures that if Playnite is closed while one or more games are running, each
@@ -258,77 +244,62 @@ namespace GsPlugin.Services {
         /// the process exits mid-call, the queued finish survives and is sent on next launch.
         /// </remarks>
         public async Task OnApplicationStoppedAsync() {
+            var pendingFinishes = new List<PendingScrobble>();
             try {
-                if (GsDataManager.IsOptedOut) return;
-
-                if (GsDataManager.Data.Flags.Contains("no-scrobble")) {
-                    _logger.Info("Scrobbling disabled, skipping application stop cleanup");
-                    return;
-                }
-
-                // Snapshot so we don't enumerate a collection that OnGameStoppedAsync could be
-                // concurrently mutating, and so each session's cleanup is independent below.
+                if (GsDataManager.IsOptedOut || GsDataManager.Data.Flags.Contains("no-scrobble")) return;
+                var installId = GsDataManager.Data.InstallID;
+                var generation = GsDataManager.Data.IdentityGeneration;
+                var at = DateTime.Now;
                 var activeSessions = GsDataManager.SnapshotActiveSessions();
-                if (activeSessions.Count == 0) {
-                    _logger.Debug("No active session to clean up on application stop");
-                    return;
-                }
-
-                _logger.Info($"Application stopping with {activeSessions.Count} active session(s), finishing scrobble session(s)");
-
-                DateTime localDate = DateTime.Now;
-
-                foreach (var kvp in activeSessions) {
-                    var gameId = kvp.Key;
-                    var sessionId = kvp.Value;
-
-                    // Deliberately not BuildFinishReq: the shutdown finish carries no game fields,
-                    // only the session and a shutdown reason.
-                    var finishData = new ScrobbleFinishReq {
-                        user_id = GsDataManager.InstallIdForBody,
-                        session_id = sessionId,
-                        metadata = new { reason = "application_stopped" },
-                        finished_at = localDate.ToString(ScrobbleTimestampFormat)
-                    };
-                    var pendingFinish = new PendingScrobble {
+                foreach (var entry in activeSessions) {
+                    pendingFinishes.Add(new PendingScrobble {
                         Type = "finish",
-                        FinishData = finishData,
-                        QueuedAt = localDate
-                    };
-                    // Durable write happens before any await — see remarks above. Once the finish
-                    // is queued, the pending-scrobble queue is the source of truth for completing
-                    // it, so the active-session marker is cleared immediately rather than only on
-                    // live-send success — otherwise it lingers indefinitely (the app is shutting
-                    // down, so there is no later OnGameStoppedAsync to clear it) and a subsequent
-                    // application-stop cycle would re-enqueue a duplicate finish for this game.
-                    GsDataManager.EnqueuePendingScrobble(pendingFinish);
-                    ClearActiveSession(gameId);
+                        QueuedAt = at,
+                        FinishData = new ScrobbleFinishReq {
+                            user_id = GsDataManager.InstallIdForBody,
+                            game_id = entry.Key,
+                            session_id = entry.Value,
+                            metadata = new { reason = "application_stopped" },
+                            finished_at = FormatScrobbleTimestamp(at)
+                        }
+                    });
+                }
+                // Starts can still be awaiting the server during shutdown. Their durable
+                // finishes pair with those queued starts on response or on the next launch.
+                foreach (var entry in _runningGames.ToArray()) {
+                    if (activeSessions.ContainsKey(entry.Key)) continue;
+                    pendingFinishes.Add(new PendingScrobble {
+                        Type = "finish",
+                        QueuedAt = at,
+                        FinishData = BuildFinishReq(entry.Value, null, at)
+                    });
+                }
+                if (pendingFinishes.Count == 0) return;
 
+                foreach (var pending in pendingFinishes) GsDataManager.ClaimPendingScrobble(pending);
+                // This single durable write covers every session before the first await.
+                if (!GsDataManager.QueueSessionFinishesAndClearActive(activeSessions, pendingFinishes, installId, generation)) return;
+                _runningGames.Clear();
+                foreach (var pending in pendingFinishes) {
+                    if (!IsCurrentIdentity(installId, generation)) break;
+                    if (string.IsNullOrEmpty(pending.FinishData.session_id)
+                        || GsDataManager.HasEarlierPendingScrobble(pending)) continue;
                     try {
-                        // Re-check opt-out before sending data (user may have opted out mid-flight)
-                        if (GsDataManager.IsOptedOut) continue;
-
-                        var finishResponse = await _apiClient.FinishGameSession(finishData);
-                        if (finishResponse != null) {
-                            GsDataManager.RemovePendingScrobble(pendingFinish);
-                            _logger.Info($"Successfully cleaned up active session on application stop for game ID: {gameId}");
-                        }
-                        else {
-                            _logger.Error($"Failed to finish active session on application stop for game ID: {gameId}. Left queued for retry.");
-                        }
+                        var response = await _apiClient.FinishGameSession(pending.FinishData);
+                        if (response != null) GsDataManager.CompletePendingScrobble(pending);
                     }
                     catch (Exception ex) {
-                        _logger.Error(ex, $"Error finishing session on application stop for game ID: {gameId}. Left queued for retry.");
+                        _logger.Error(ex, "Shutdown finish remains queued for retry.");
                     }
                 }
             }
             catch (Exception ex) {
-                _logger.Error(ex, "Error cleaning up active session on application stop");
+                _logger.Error(ex, "Error preparing shutdown scrobbles.");
+            }
+            finally {
+                foreach (var pending in pendingFinishes) GsDataManager.ReleasePendingScrobble(pending);
             }
         }
-
-
-
         #region v3 Sync Methods
 
         /// <summary>

--- a/Services/GsScrobblingService.cs
+++ b/Services/GsScrobblingService.cs
@@ -969,7 +969,9 @@ namespace GsPlugin.Services {
                             var dedupedByName = new Dictionary<string, AchievementItemDto>();
                             foreach (var a in achievements) {
                                 dedupedByName[a.Name ?? ""] = new AchievementItemDto {
-                                    name = a.Name,
+                                    // See the diff-sync site: "" not null, so the C# and JS sort
+                                    // orders agree on empty achievement names.
+                                    name = a.Name ?? "",
                                     description = a.Description,
                                     date_unlocked = a.DateUnlocked,
                                     is_unlocked = a.IsUnlocked,
@@ -1151,7 +1153,12 @@ namespace GsPlugin.Services {
                         var dedupedByName = new Dictionary<string, AchievementItemDto>();
                         foreach (var a in achievements) {
                             dedupedByName[a.Name ?? ""] = new AchievementItemDto {
-                                name = a.Name,
+                                // "" not null: the hash joins names with string.Join, which renders a
+                                // null as "", but JS Array.sort coerces null via ToString to the
+                                // literal "null" and orders it among the n's. Same characters, different
+                                // order, different digest -- a permanent hash mismatch. Normalizing here
+                                // leaves the C# digest unchanged and makes both sides agree.
+                                name = a.Name ?? "",
                                 description = a.Description,
                                 date_unlocked = a.DateUnlocked,
                                 is_unlocked = a.IsUnlocked,
@@ -1255,7 +1262,7 @@ namespace GsPlugin.Services {
         private static void HandleCooldownResponse(AsyncQueuedResponse response, bool isDiffSync = false) {
             DateTime? expiresAt = null;
             if (!string.IsNullOrEmpty(response.cooldownExpiresAt)
-                && DateTime.TryParse(response.cooldownExpiresAt, null,
+                && DateTime.TryParse(response.cooldownExpiresAt, CultureInfo.InvariantCulture,
                     System.Globalization.DateTimeStyles.RoundtripKind, out var parsed)) {
                 expiresAt = parsed.ToUniversalTime();
             }

--- a/Services/GsSuccessStoryHelper.cs
+++ b/Services/GsSuccessStoryHelper.cs
@@ -37,70 +37,68 @@ namespace GsPlugin.Services {
             return (achievements.Count(a => a.IsUnlocked), achievements.Count);
         }
 
-        public override List<AchievementItem> GetAchievements(Guid gameId) {
-            return SafeRead("Achievement lookup", gameId, DescribeReadFailure, () => {
-                if (_dataPath == null || !Directory.Exists(_dataPath)) return null;
+        protected override List<AchievementItem> ReadAchievementsCore(Guid gameId) {
+            if (_dataPath == null || !Directory.Exists(_dataPath)) return null;
 
-                var filePath = Path.Combine(_dataPath, $"{gameId}.json");
-                if (!File.Exists(filePath)) return null;
+            var filePath = Path.Combine(_dataPath, $"{gameId}.json");
+            if (!File.Exists(filePath)) return null;
 
-                byte[] fileBytes;
-                using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read,
-                           FileShare.ReadWrite | FileShare.Delete)) {
-                    using (var ms = new MemoryStream()) {
-                        stream.CopyTo(ms);
-                        fileBytes = ms.ToArray();
-                    }
+            byte[] fileBytes;
+            using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read,
+                       FileShare.ReadWrite | FileShare.Delete)) {
+                using (var ms = new MemoryStream()) {
+                    stream.CopyTo(ms);
+                    fileBytes = ms.ToArray();
                 }
+            }
 
-                using (var doc = JsonDocument.Parse(fileBytes)) {
-                    var root = doc.RootElement;
+            using (var doc = JsonDocument.Parse(fileBytes)) {
+                var root = doc.RootElement;
 
-                    if (root.TryGetProperty("IsIgnored", out var ignored) && ignored.GetBoolean())
-                        return null;
+                if (root.TryGetProperty("IsIgnored", out var ignored) && ignored.GetBoolean())
+                    return null;
 
-                    if (!root.TryGetProperty("Items", out var items) || items.ValueKind != JsonValueKind.Array)
-                        return null;
+                if (!root.TryGetProperty("Items", out var items) || items.ValueKind != JsonValueKind.Array)
+                    return null;
 
-                    var result = new List<AchievementItem>();
-                    foreach (var item in items.EnumerateArray()) {
-                        var name = item.TryGetProperty("Name", out var n) ? n.GetString() : null;
-                        var description = item.TryGetProperty("Description", out var d) ? d.GetString() : null;
+                var result = new List<AchievementItem>();
+                foreach (var item in items.EnumerateArray()) {
+                    var name = item.TryGetProperty("Name", out var n) ? n.GetString() : null;
+                    var description = item.TryGetProperty("Description", out var d) ? d.GetString() : null;
 
-                        DateTime? dateUnlocked = null;
-                        if (item.TryGetProperty("DateUnlocked", out var du) && du.ValueKind != JsonValueKind.Null) {
-                            if (du.TryGetDateTime(out var parsed)
-                                && parsed > DateTime.MinValue && parsed.Year > 1) {
-                                dateUnlocked = parsed;
-                            }
+                    DateTime? dateUnlocked = null;
+                    if (item.TryGetProperty("DateUnlocked", out var du) && du.ValueKind != JsonValueKind.Null) {
+                        if (du.TryGetDateTime(out var parsed)
+                            && parsed > DateTime.MinValue && parsed.Year > 1) {
+                            dateUnlocked = parsed;
                         }
-
-                        float? rarityPercent = null;
-                        if (item.TryGetProperty("Percent", out var pct) && pct.ValueKind == JsonValueKind.Number) {
-                            rarityPercent = (float)pct.GetDouble();
-                        }
-
-                        bool isUnlocked = dateUnlocked.HasValue;
-
-                        result.Add(new AchievementItem {
-                            Name = name,
-                            Description = description,
-                            DateUnlocked = isUnlocked ? dateUnlocked : null,
-                            IsUnlocked = isUnlocked,
-                            RarityPercent = rarityPercent
-                        });
                     }
 
-                    return result.Count > 0 ? result : null;
+                    float? rarityPercent = null;
+                    if (item.TryGetProperty("Percent", out var pct) && pct.ValueKind == JsonValueKind.Number) {
+                        rarityPercent = (float)pct.GetDouble();
+                    }
+
+                    bool isUnlocked = dateUnlocked.HasValue;
+
+                    result.Add(new AchievementItem {
+                        Name = name,
+                        Description = description,
+                        DateUnlocked = isUnlocked ? dateUnlocked : null,
+                        IsUnlocked = isUnlocked,
+                        RarityPercent = rarityPercent
+                    });
                 }
-            });
+
+                return result.Count > 0 ? result : null;
+            }
         }
 
         /// <summary>
         /// Wording for the failure types these file reads distinguish; null means the
         /// generic "{operation} failed" message applies.
         /// </summary>
-        private static string DescribeReadFailure(Exception ex) {
+        protected override string DescribeAchievementReadFailure(Exception ex) {
             if (ex is JsonException) return "JSON parse error";
             if (ex is IOException) return "File read error";
             return null;

--- a/Services/IAchievementProvider.cs
+++ b/Services/IAchievementProvider.cs
@@ -5,6 +5,42 @@ using Playnite.SDK.Plugins;
 
 namespace GsPlugin.Services {
     /// <summary>
+    /// A successful read may contain no achievements. An unavailable read must never be
+    /// interpreted as a request to delete previously synchronized achievements.
+    /// </summary>
+    public sealed class AchievementReadResult {
+        public bool IsAvailable { get; }
+        public List<AchievementItem> Achievements { get; }
+        public string ProviderName { get; }
+
+        private AchievementReadResult(bool isAvailable, List<AchievementItem> achievements, string providerName) {
+            IsAvailable = isAvailable;
+            Achievements = achievements ?? new List<AchievementItem>();
+            ProviderName = providerName;
+        }
+
+        public static AchievementReadResult Available(List<AchievementItem> achievements, string providerName = null) =>
+            new AchievementReadResult(true, achievements, providerName);
+
+        public static AchievementReadResult Unavailable(string providerName = null) =>
+            new AchievementReadResult(false, null, providerName);
+
+        public static AchievementReadResult Read(IAchievementProvider provider, Guid gameId) {
+            if (provider is IReliableAchievementProvider reliable) {
+                return reliable.ReadAchievements(gameId);
+            }
+            var items = provider.GetAchievements(gameId);
+            // Older providers cannot distinguish absence from a read failure. Preserve the
+            // existing baseline when their answer is ambiguous.
+            return items == null ? Unavailable(provider.ProviderName) : Available(items, provider.ProviderName);
+        }
+    }
+
+    public interface IReliableAchievementProvider {
+        AchievementReadResult ReadAchievements(Guid gameId);
+    }
+
+    /// <summary>
     /// Reads the Version field from extension.yaml next to the plugin DLL.
     /// Assembly versions are often wrong in Playnite plugins; extension.yaml is authoritative.
     /// </summary>

--- a/View/GsPluginSettingsViewModel.cs
+++ b/View/GsPluginSettingsViewModel.cs
@@ -158,6 +158,8 @@ namespace GsPlugin.Models {
 
             // Sync settings to GsDataManager
             GsDataManager.MutateAndSave(d => {
+                d.Theme = savedSettings.Theme;
+                d.UpdateFlags(savedSettings.DisableSentry, savedSettings.DisableScrobbling, savedSettings.DisablePostHog);
                 d.NewDashboardExperience = savedSettings.NewDashboardExperience;
                 d.SyncAchievements = savedSettings.SyncAchievements;
                 d.ShowUpdateNotifications = savedSettings.ShowUpdateNotifications;
@@ -230,6 +232,9 @@ namespace GsPlugin.Models {
                 d.ShowUpdateNotifications = s.ShowUpdateNotifications;
                 d.ShowImportantNotifications = s.ShowImportantNotifications;
             });
+
+            GsSentry.ApplyPreferences();
+            GsPostHog.ApplyPreferences();
 
             GsLogger.ShowDebugInfoBox($"Settings saved:\nTheme: {Settings.Theme}\nNew Dashboard: {Settings.NewDashboardExperience}\nFlags: {string.Join(", ", GsDataManager.Data.Flags)}", "Debug - Settings Saved");
         }
@@ -408,6 +413,8 @@ namespace GsPlugin.Models {
                     // Capture analytics before opt-out disables telemetry
                     GsPostHog.Capture("data_deletion_requested");
                     GsDataManager.PerformOptOut();
+                    GsSentry.ApplyPreferences();
+                    GsPostHog.ApplyPreferences();
                     GsSyncHashIndex.ClearAll();
                     Settings.DeleteStatusMessage = GsLocalization.Get("LOCGsPluginDeleteSuccess", "Your data has been deleted. The plugin is now disabled.");
                     // Notify UI to refresh connection status and button visibility
@@ -418,6 +425,8 @@ namespace GsPlugin.Models {
                     // Sync local state so the Delete button hides instead of looping on a
                     // failure the user can never clear by retrying.
                     GsDataManager.PerformOptOut();
+                    GsSentry.ApplyPreferences();
+                    GsPostHog.ApplyPreferences();
                     GsSyncHashIndex.ClearAll();
                     Settings.DeleteStatusMessage = GsLocalization.Get("LOCGsPluginDeleteAlreadyDone",
                         "Your data has already been deleted. The plugin is now disabled.");
@@ -466,6 +475,8 @@ namespace GsPlugin.Models {
                 }
 
                 GsDataManager.PerformOptIn();
+                GsSentry.ApplyPreferences();
+                GsPostHog.ApplyPreferences();
                 Settings.DeleteStatusMessage = GsLocalization.Get("LOCGsPluginOptBackInSuccess", "Plugin re-enabled. Please restart Playnite to resume syncing.");
                 OnLinkingStatusChanged();
             }

--- a/View/MySidebarView.xaml.cs
+++ b/View/MySidebarView.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using GsPlugin.Api;
@@ -11,13 +12,22 @@ namespace GsPlugin.View {
     public partial class MySidebarView : UserControl, IDisposable {
 
         private readonly IGsApiClient _apiClient;
+        private readonly string _userDataFolder;
         private bool _webView2Ready;
         private DateTime _lastNavigatedAtUtc = DateTime.MinValue;
         private bool _disposed;
 
-        public MySidebarView(IGsApiClient apiClient) {
+        /// <param name="userDataFolder">
+        /// Private WebView2 profile directory. Without one, WebView2 falls back to a folder derived
+        /// from the host process, which every Playnite extension hosting a WebView2 shares — so the
+        /// cookie jar, localStorage and browsing history of the signed-in gamescrobbler.com dashboard
+        /// (including the access_token carried in the URL) would be readable by any other extension.
+        /// Passing null keeps the shared default, for callers that cannot supply a path.
+        /// </param>
+        public MySidebarView(IGsApiClient apiClient, string userDataFolder = null) {
             InitializeComponent();
             _apiClient = apiClient;
+            _userDataFolder = userDataFolder;
 
             // One approach is to wait until the control is actually loaded in the visual tree.
             this.Loaded += MySidebarView_Loaded;
@@ -28,7 +38,21 @@ namespace GsPlugin.View {
         private async void MySidebarView_Loaded(object sender, RoutedEventArgs e) {
             try {
                 // Ensure the CoreWebView2 is ready to receive commands
-                await MyWebView2.EnsureCoreWebView2Async();
+                CoreWebView2Environment environment = null;
+                if (!string.IsNullOrEmpty(_userDataFolder)) {
+                    try {
+                        Directory.CreateDirectory(_userDataFolder);
+                        environment = await CoreWebView2Environment.CreateAsync(
+                            browserExecutableFolder: null, userDataFolder: _userDataFolder);
+                    }
+                    catch (Exception envEx) {
+                        // Fall back to the shared default rather than leaving the dashboard broken;
+                        // a private profile is a hardening measure, not a functional requirement.
+                        GsLogger.Warn($"Could not create a private WebView2 profile, using the default: {envEx.Message}");
+                    }
+                }
+
+                await MyWebView2.EnsureCoreWebView2Async(environment);
 
                 if (MyWebView2?.CoreWebView2 == null) {
                     GsLogger.Error("WebView2 initialization failed: CoreWebView2 is null after initialization");

--- a/installer_manifest.yaml
+++ b/installer_manifest.yaml
@@ -6,7 +6,7 @@ Packages:
     ReleaseDate: 2026-08-14
     PackageUrl: https://github.com/game-scrobbler/gs-playnite/releases/download/GsPlugin-v2.8.1/GsPlugin-v2.8.1.pext
     Changelog:
-      - Your library and achievement syncs are now double-checked, so stats no longer look \"synced\" if the upload actually failed on our end.
+      - Your library and achievement syncs are now double-checked, so stats no longer look "synced" if the upload actually failed on our end.
       - Fixed a rare issue where Playnite could hang on exit while closing in the background.
   - Version: 2.8.0
     RequiredApiVersion: 6.12.0
@@ -15,8 +15,8 @@ Packages:
     Changelog:
       - You can now enjoy Game Scrobbler while playing in Fullscreen mode, once your theme adds support for it.
       - Fixed a mix-up where achievements could show frozen or incomplete progress if you'd previously used a different achievement tracker.
-      - Fixed \\"Delete My Data\\" sometimes getting stuck or failing forever, including when your data was already deleted.
-      - Fixed account linking sometimes showing \\"Successfully linked!\\" while your account was actually still disconnected.
+      - Fixed "Delete My Data" sometimes getting stuck or failing forever, including when your data was already deleted.
+      - Fixed account linking sometimes showing "Successfully linked!" while your account was actually still disconnected.
   - Version: 2.7.0
     RequiredApiVersion: 6.12.0
     ReleaseDate: 2026-07-15
@@ -24,7 +24,7 @@ Packages:
     Changelog:
       - Your library and achievement uploads now sync in smaller, sturdier batches, so even huge libraries upload reliably.
       - Fixed an issue where your play stats or achievements could get out of sync after an interrupted sync.
-      - Renamed the \\\"new dashboard\\\" toggle to \\\"beta channel\\\" in settings for clarity.
+      - Renamed the "new dashboard" toggle to "beta channel" in settings for clarity.
       - Made background error reporting more reliable so it can no longer cause slowdowns when Playnite closes.
   - Version: 2.6.0
     RequiredApiVersion: 6.12.0

--- a/scripts/update-installer-manifest.Tests.ps1
+++ b/scripts/update-installer-manifest.Tests.ps1
@@ -1,72 +1,48 @@
 <#
 .SYNOPSIS
-    Pester tests for scripts/update-installer-manifest.ps1, focused on the
-    changes introduced in this PR: preferring a curated "### Highlights"
-    changelog section over the raw Features/Bug Fixes bullets (falling back
-    to the raw bullets when no Highlights section exists), and the removal of
-    the dead "marketing note" placeholder.
+    Pester tests for changelog selection and lossless installer YAML updates.
 
 .DESCRIPTION
     The script has two hard, non-parameterized dependencies on its own
     location ($PSScriptRoot):
       - it imports "..\powershell-yaml\powershell-yaml.psd1"
       - it reads/writes "..\installer_manifest.yaml"
-    To test it without ever touching the real repository files (and without a
-    network dependency on the real powershell-yaml module, which is
-    unrelated to the logic this PR changes), each test copies the script into
-    an isolated temp workspace that reproduces this relative layout, along
-    with a minimal stub "powershell-yaml" module. The stub's ConvertFrom-Yaml
-    ignores the piped YAML text and instead returns a fixture object supplied
-    via the PESTER_STUB_MANIFEST_JSON environment variable, so tests can
-    control the "existing manifest" input precisely without a real YAML
-    parser. The script never calls ConvertTo-Yaml (it builds YAML manually),
-    so that's the only function the stub needs to provide.
+    Each test copies the script and the real powershell-yaml module into an
+    isolated temp workspace. CI checks out that module at the repository root.
+    For local runs, set GS_TEST_YAML_MODULE_PATH to powershell-yaml.psd1 from
+    a checkout, or install the module. Tests perform no network requests.
+    Every output is parsed by the real parser, including the second input
+    when testing repeated updates. JSON seed fixtures are valid YAML too.
 
-    The script contains no `exit` calls, so it is safe to invoke directly
-    (via the call operator) in-process.
+    The updater runs in a child Windows PowerShell process on Windows, matching
+    the release workflow; elsewhere it uses pwsh. This also isolates module
+    imports between updates.
 
     Run with: Invoke-Pester -Path scripts/update-installer-manifest.Tests.ps1
 #>
 
 BeforeAll {
     $script:RealScriptPath = Join-Path $PSScriptRoot 'update-installer-manifest.ps1'
+    $script:YamlModulePath = $env:GS_TEST_YAML_MODULE_PATH
+    if (-not $script:YamlModulePath) {
+        $script:YamlModulePath = Join-Path $PSScriptRoot '..\powershell-yaml\powershell-yaml.psd1'
+    }
+    if (-not (Test-Path -LiteralPath $script:YamlModulePath)) {
+        $script:YamlModulePath = (Get-Module -ListAvailable powershell-yaml | Select-Object -First 1).Path
+    }
+    if (-not $script:YamlModulePath) {
+        throw 'Real YAML tests require powershell-yaml. Set GS_TEST_YAML_MODULE_PATH or install the module.'
+    }
+    Import-Module $script:YamlModulePath -Force -ErrorAction Stop
+    $script:ScriptHost = if ($env:OS -eq 'Windows_NT') { 'powershell.exe' } else { 'pwsh' }
 
     function New-TestWorkspace {
         $workspace = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
         New-Item -ItemType Directory -Path $workspace -Force | Out-Null
         New-Item -ItemType Directory -Path (Join-Path $workspace 'scripts') -Force | Out-Null
-        New-Item -ItemType Directory -Path (Join-Path $workspace 'powershell-yaml') -Force | Out-Null
-
         Copy-Item -Path $script:RealScriptPath -Destination (Join-Path $workspace 'scripts\update-installer-manifest.ps1')
-
-        # The real installer_manifest.yaml content is irrelevant: the stub
-        # ConvertFrom-Yaml below ignores it. The file just needs to exist so
-        # Get-Content does not throw.
-        Set-Content -Path (Join-Path $workspace 'installer_manifest.yaml') -Value 'placeholder' -NoNewline
-
-        $stubModule = @'
-function ConvertFrom-Yaml {
-    [CmdletBinding()]
-    param([Parameter(ValueFromPipeline = $true)][string]$InputObject)
-    process {
-        # Test stub: real YAML parsing is intentionally not exercised here.
-        # The fixture "existing manifest" object is supplied out-of-band via
-        # PESTER_STUB_MANIFEST_JSON so tests can control it precisely.
-        Get-Content -Path $env:PESTER_STUB_MANIFEST_JSON -Raw | ConvertFrom-Json
-    }
-}
-Export-ModuleMember -Function ConvertFrom-Yaml
-'@
-        Set-Content -Path (Join-Path $workspace 'powershell-yaml\powershell-yaml.psm1') -Value $stubModule
-
-        $stubManifest = @'
-@{
-    ModuleVersion = '1.0.0'
-    RootModule = 'powershell-yaml.psm1'
-    FunctionsToExport = @('ConvertFrom-Yaml')
-}
-'@
-        Set-Content -Path (Join-Path $workspace 'powershell-yaml\powershell-yaml.psd1') -Value $stubManifest
+        Copy-Item -LiteralPath (Split-Path -Parent $script:YamlModulePath) `
+            -Destination (Join-Path $workspace 'powershell-yaml') -Recurse
 
         return $workspace
     }
@@ -77,27 +53,24 @@ Export-ModuleMember -Function ConvertFrom-Yaml
             [Parameter(Mandatory)] [string]$Version,
             [Parameter(Mandatory)] [string]$TagName,
             [Parameter(Mandatory)] [string]$ChangelogFile,
-            [Parameter(Mandatory)] [string]$ExistingManifestJsonPath
+            [string]$ExistingManifestJsonPath
         )
 
         $scriptPath = Join-Path $Workspace 'scripts\update-installer-manifest.ps1'
-        $previous = [Environment]::GetEnvironmentVariable('PESTER_STUB_MANIFEST_JSON')
-        [Environment]::SetEnvironmentVariable('PESTER_STUB_MANIFEST_JSON', $ExistingManifestJsonPath)
-
-        try {
-            # *>&1 merges all streams (including the Information stream that
-            # Write-Host writes to) into the success stream so Out-String
-            # actually captures the script's Write-Host output.
-            $output = & $scriptPath -Version $Version -TagName $TagName -ChangelogFile $ChangelogFile *>&1 | Out-String
-        }
-        finally {
-            [Environment]::SetEnvironmentVariable('PESTER_STUB_MANIFEST_JSON', $previous)
-        }
-
         $resultYamlPath = Join-Path $Workspace 'installer_manifest.yaml'
+        if ($ExistingManifestJsonPath) {
+            Copy-Item -LiteralPath $ExistingManifestJsonPath -Destination $resultYamlPath -Force
+        }
+        $output = & $script:ScriptHost -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $scriptPath `
+            -Version $Version -TagName $TagName -ChangelogFile $ChangelogFile 2>&1 | Out-String
+        if ($LASTEXITCODE -ne 0) {
+            throw "Manifest updater failed with exit code ${LASTEXITCODE}: $output"
+        }
+        $manifestRaw = [System.IO.File]::ReadAllText($resultYamlPath)
         [PSCustomObject]@{
             Output      = $output
-            ManifestRaw = (Get-Content -Path $resultYamlPath -Raw)
+            ManifestRaw = $manifestRaw
+            Manifest    = ($manifestRaw | ConvertFrom-Yaml)
         }
     }
 
@@ -130,7 +103,12 @@ Describe 'update-installer-manifest.ps1' {
     }
 
     AfterEach {
-        Remove-Item -Path $script:Workspace -Recurse -Force -ErrorAction SilentlyContinue
+        $cleanupPath = [System.IO.Path]::GetFullPath($script:Workspace)
+        $tempRoot = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath()).TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+        if (-not $cleanupPath.StartsWith($tempRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "Refusing to remove test workspace outside the temp directory: $cleanupPath"
+        }
+        Remove-Item -LiteralPath $cleanupPath -Recurse -Force -ErrorAction SilentlyContinue
     }
 
     Context 'when a "### Highlights" section exists for the version' {
@@ -284,6 +262,79 @@ Describe 'update-installer-manifest.ps1' {
         }
     }
 
+    Context 'YAML string round trips' {
+        It 'preserves quotes, paths, YAML-looking values, and Unicode across repeated updates' {
+            $entries = @(
+                'Fixed "Delete My Data" sometimes getting stuck.',
+                'Support imports from C:\Games: shared library',
+                'Keep the literal sequence \n and a trailing backslash\',
+                "Your friend's [library] #1: ready & waiting",
+                'true', 'null', '123', '2026-09-05',
+                'Faster café launches — بازی‌ها 🎮'
+            )
+            $changelog = "## [2.0.0] (2026-05-01)`n`n### Highlights`n`n" +
+                (($entries | ForEach-Object { "* $_" }) -join "`n")
+            [System.IO.File]::WriteAllText($script:ChangelogPath, $changelog)
+            $existingManifest = New-ExistingManifestFixture -Workspace $script:Workspace -Version '1.9.0'
+
+            $first = Invoke-ManifestScript -Workspace $script:Workspace -Version '2.0.0' -TagName 'GsPlugin-v2.0.0' `
+                -ChangelogFile $script:ChangelogPath -ExistingManifestJsonPath $existingManifest
+            $second = Invoke-ManifestScript -Workspace $script:Workspace -Version '2.0.0' -TagName 'GsPlugin-v2.0.0' `
+                -ChangelogFile $script:ChangelogPath
+
+            $second.ManifestRaw | Should -BeExactly $first.ManifestRaw
+            $second.Manifest.Packages.Count | Should -Be 2
+            $actual = @($second.Manifest.Packages[0].Changelog)
+            $actual.Count | Should -Be $entries.Count
+            for ($i = 0; $i -lt $entries.Count; $i++) {
+                $actual[$i] | Should -BeOfType [string]
+                $actual[$i] | Should -BeExactly $entries[$i]
+            }
+        }
+
+        It 'preserves older entries containing quotes, control characters, and backslashes' {
+            $oldEntries = @(
+                'Already fixed "Delete My Data".',
+                'Paths: C:\Games\new\ and \\server\games',
+                "A tab`tand a newline`nare kept.",
+                'A backslash immediately before a quote: \"'
+            )
+            $existingManifest = New-ExistingManifestFixture -Workspace $script:Workspace -Version '1.9.0'
+            $fixture = Get-Content -LiteralPath $existingManifest -Raw | ConvertFrom-Json
+            $fixture.Packages[0].Changelog = $oldEntries
+            [System.IO.File]::WriteAllText($existingManifest, ($fixture | ConvertTo-Json -Depth 5))
+            [System.IO.File]::WriteAllText($script:ChangelogPath, "## [2.0.0]`n`n### Highlights`n`n* New release")
+
+            $first = Invoke-ManifestScript -Workspace $script:Workspace -Version '2.0.0' -TagName 'GsPlugin-v2.0.0' `
+                -ChangelogFile $script:ChangelogPath -ExistingManifestJsonPath $existingManifest
+            $second = Invoke-ManifestScript -Workspace $script:Workspace -Version '2.0.0' -TagName 'GsPlugin-v2.0.0' `
+                -ChangelogFile $script:ChangelogPath
+
+            $second.ManifestRaw | Should -BeExactly $first.ManifestRaw
+            $actual = @($second.Manifest.Packages[1].Changelog)
+            $actual.Count | Should -Be $oldEntries.Count
+            for ($i = 0; $i -lt $oldEntries.Count; $i++) {
+                $actual[$i] | Should -BeExactly $oldEntries[$i]
+            }
+        }
+
+        It 'keeps the repaired historical highlights identical to the reviewed changelog' {
+            $manifest = [System.IO.File]::ReadAllText((Join-Path $PSScriptRoot '..\installer_manifest.yaml')) | ConvertFrom-Yaml
+            $changelog = [System.IO.File]::ReadAllText((Join-Path $PSScriptRoot '..\CHANGELOG.md'))
+            foreach ($version in @('2.8.1', '2.8.0', '2.7.0')) {
+                $section = [regex]::Match($changelog, "## \[$([regex]::Escape($version))\].*?\n(.*?)(?=\n## \[|$)", 'Singleline').Groups[1].Value
+                $highlights = [regex]::Match($section, '### Highlights\s*\n(.*?)(?=\n###|$)', 'Singleline').Groups[1].Value
+                $expected = @([regex]::Matches($highlights, '^\* (.+)', 'Multiline') | ForEach-Object { $_.Groups[1].Value.TrimEnd() })
+                $package = $manifest.Packages | Where-Object { $_.Version -eq $version }
+                $actual = @($package.Changelog)
+                $actual.Count | Should -Be $expected.Count
+                for ($i = 0; $i -lt $expected.Count; $i++) {
+                    $actual[$i] | Should -BeExactly $expected[$i]
+                }
+            }
+        }
+    }
+
     Context 'no leftover marketing-note placeholder' {
         It 'never injects any entry beyond what was parsed from the changelog' {
             $changelog = @'
@@ -308,7 +359,7 @@ Describe 'update-installer-manifest.ps1' {
             $changelogLines = @([regex]::Matches($newEntryBlock, '^ {6}-\s+(.+)$', 'Multiline') | ForEach-Object { $_.Groups[1].Value.Trim() })
 
             $changelogLines.Count | Should -Be 1
-            $changelogLines[0] | Should -Be 'Only entry'
+            $result.Manifest.Packages[0].Changelog[0] | Should -Be 'Only entry'
         }
     }
 }

--- a/scripts/update-installer-manifest.ps1
+++ b/scripts/update-installer-manifest.ps1
@@ -12,6 +12,8 @@ param(
     [string]$ChangelogFile = "CHANGELOG.md"
 )
 
+$ErrorActionPreference = 'Stop'
+
 # Import powershell-yaml module
 Import-Module "$PSScriptRoot\..\powershell-yaml\powershell-yaml.psd1" -Force
 
@@ -25,10 +27,10 @@ Write-Host "Package URL: $packageUrl"
 Write-Host "Release Date: $releaseDate"
 
 # Read the current manifest
-$manifest = Get-Content -Path $manifestPath -Raw | ConvertFrom-Yaml
+$manifest = [System.IO.File]::ReadAllText($manifestPath) | ConvertFrom-Yaml
 
 # Extract changelog entries for this version from CHANGELOG.md
-$changelogContent = Get-Content -Path $ChangelogFile -Raw
+$changelogContent = [System.IO.File]::ReadAllText((Resolve-Path -LiteralPath $ChangelogFile))
 $versionPattern = "## \[$Version\].*?\n(.*?)(?=\n## \[|$)"
 $changelogMatch = [regex]::Match($changelogContent, $versionPattern, [System.Text.RegularExpressions.RegexOptions]::Singleline)
 
@@ -138,22 +140,17 @@ foreach ($package in $manifest.Packages) {
         # Remove trailing " ()" artifacts from changelog parsing
         $entryStr = $entryStr -replace '\s*\(\)\s*$', ''
 
-        # Escape quotes in the entry
-        $escapedEntry = $entryStr -replace '"', '\"'
-
-        # Quote entries that contain special YAML characters
-        if ($escapedEntry -match '[:\[\]{}@&*#?|<>%`]|^-|\s+$') {
-            $yamlLines += "      - `"$escapedEntry`""
-        } else {
-            $yamlLines += "      - $escapedEntry"
-        }
+        # JSON string literals are also valid YAML double-quoted scalars. Always
+        # quote strings so YAML cannot reinterpret true, null, dates, or numbers,
+        # and let the serializer escape quotes, backslashes, and control chars.
+        $yamlLines += "      - $(ConvertTo-Json -InputObject $entryStr -Compress)"
     }
 }
 
 $yamlContent = $yamlLines -join "`n"
 
 # Write to file
-Set-Content -Path $manifestPath -Value $yamlContent -NoNewline
+[System.IO.File]::WriteAllText($manifestPath, $yamlContent, [System.Text.UTF8Encoding]::new($false))
 
 Write-Host "Successfully updated $manifestPath"
 Write-Host ""


### PR DESCRIPTION
## Changes

Persist session starts and stops before network waits, keep replay ordered,
and queue every shutdown finish atomically. Delayed responses can no longer
lose short sessions or clear a newer session for the same game.

Require confirmed server-job completion before advancing sync baselines.
Unavailable achievement reads retain existing data, transient HTTP errors
remain retryable, and expired circuits can recover through queue replay.

- Preserve unreadable installation data and roll back failed durable writes.
- Fence account and sync completions against identity changes and opt-out.
- Apply telemetry preferences throughout SDK lifetimes, including buffered
  and automatic traffic; redact standard and relocated Windows profile roots
  in error reports with escaped matching and a safe fallback.
- Normalize timestamps and hash inputs independently of Windows locale.
- Require exact public-key token matches when resolving dependencies, including
  unsigned requests. Use a private dashboard browser profile
  when available, and report plugin versions consistently on API requests.
- Preserve manifest text across YAML updates, run release-script tests in CI,
  and align Sentry release identifiers with portable debug symbols.

The implementation is split into 17 topical commits with detailed bodies.
The final three commits cover assembly signing identity (`a2a6304`), relocated
profile redaction (`8aa6ebb`), and explicit transaction snapshots for queue
completion and rejection (`0deb119`). The snapshot refactor removes the
callbacks' dependency on global data assignment order while preserving
launch pairing and rollback behavior.
A merge from main preserves the newly published 2.8.2 manifest entry while
retaining the historical quote repairs.

## Validation

- Release build passed. The full C# suite passed 457/457 tests with no skips,
  including 19 new signing-identity and profile-redaction regression cases.
- The first full run had one failure in the existing
  `Initialize_WhenFileExists_LoadsExistingData` test (the persisted user loaded
  as null). It passed in isolation and on the subsequent full-suite rerun;
  the cause was not established.
- All 24 PowerShell tests passed; the 10 manifest tests were rerun after
  resolving the upstream manifest merge.
- Full formatting verification, diff checks, and portable PDB verification
  passed. Normal commit hooks also passed.

Live Playnite/backend integration was not exercised. The existing
System.Net.Http assembly-reference warning remains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of scrobble uploads, session recovery, and queued synchronization during failures, restarts, or shutdowns.
  * Prevented stale account-linking responses from overwriting newer account or opt-out states.
  * Improved achievement sync handling so unavailable reads no longer erase previously synced data.
  * Standardized timestamps and hashes across regional settings.

* **Privacy & Security**
  * Telemetry now follows consent changes immediately and scrubs local profile paths from diagnostics.
  * Web content uses an isolated profile for improved stability.

* **Localization**
  * Added translated messaging when installation settings change during a request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->