### PR TITLE
fix(scrobble): classify start failures and stop per-game Sentry issues

### DIFF
--- a/Api/GsApiClient.cs
+++ b/Api/GsApiClient.cs
@@ -152,11 +152,21 @@ namespace GsPlugin.Api {
             }
 
             string url = $"{_apiBaseUrl}/api/playnite/v3/scrobble/start";
+            var diagnostics = new HttpCallDiagnostics();
+            var attempts = 0;
 
             var envelope = await _circuitBreaker.ExecuteAsync(async () => {
+                attempts++;
+                diagnostics.Reset();
                 onAttempt?.Invoke();
-                return await PostJsonAsync<ApiResponse<ScrobbleStartData>>(url, startData);
-            }, maxRetries: 2, isFailure: r => r == null);
+                return await PostJsonAsync<ApiResponse<ScrobbleStartData>>(
+                    url, startData,
+                    onStatus: status => diagnostics.StatusCode = status,
+                    parseErrorBody: true,
+                    diagnostics: diagnostics,
+                    captureExceptions: false);
+            }, maxRetries: 2, isFailure: r => r == null,
+                isPermanent: () => IsPermanentRejection(diagnostics.StatusCode));
 
             switch (envelope?.Outcome) {
                 case ApiOutcome.Success when envelope.data?.session_id != null:
@@ -173,13 +183,24 @@ namespace GsPlugin.Api {
                     return null;
 
                 case ApiOutcome.Fail:
+                case ApiOutcome.Error:
                     _logger.Warn($"Scrobble start rejected by server: [{envelope.code}] {envelope.message}");
-                    CaptureSentryMessage($"Scrobble start fail: {envelope.code}", SentryLevel.Warning, startData.game_name, startData.user_id);
+                    // Flush retries already reported the live failure; do not open a new
+                    // issue every 5 minutes for the same queued start.
+                    if (onAttempt == null) {
+                        CaptureSentryMessage(
+                            $"Scrobble start fail: {envelope.code ?? "unknown"}",
+                            SentryLevel.Warning,
+                            startData.game_name,
+                            startData.user_id,
+                            extras: ScrobbleStartFailure.BuildExtras(
+                                attempts, diagnostics, envelope.Outcome.ToString()),
+                            fingerprint: new[] { "gs-playnite", "scrobble-start-fail", envelope.code ?? "unknown" });
+                    }
                     return null;
 
                 default:
-                    GsLogger.Error("Failed to start scrobble session");
-                    CaptureSentryMessage("Failed to start scrobble session", SentryLevel.Warning, startData.game_name, startData.user_id);
+                    ReportNullEnvelopeStartFailure(startData, onAttempt != null, attempts, diagnostics);
                     return null;
             }
         }
@@ -844,13 +865,49 @@ namespace GsPlugin.Api {
         }
 
         /// <summary>
+        /// Logs a null-envelope scrobble start and, on the live path only, reports one
+        /// Sentry event with a stable fingerprint. Game/user identity stays in extras
+        /// and breadcrumbs so Sentry cannot split GS-PLAYNITE-M5-style issues per title.
+        /// </summary>
+        private static void ReportNullEnvelopeStartFailure(
+            ScrobbleStartReq startData, bool isFlushRetry, int attempts, HttpCallDiagnostics diagnostics) {
+            var extras = ScrobbleStartFailure.BuildExtras(attempts, diagnostics, outcome: null);
+            extras.TryGetValue("failure_kind", out var reason);
+            GsLogger.Error(
+                $"Failed to start scrobble session (reason={reason ?? "unknown"}, http={diagnostics?.StatusCode ?? 0}, attempts={attempts})");
+
+            if (!ScrobbleStartFailure.ShouldCapture(attempts, isFlushRetry)) {
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(startData?.game_name)) {
+                extras["game"] = startData.game_name;
+            }
+
+            CaptureSentryMessage(
+                ScrobbleStartFailure.Message,
+                SentryLevel.Warning,
+                startData?.game_name,
+                startData?.user_id,
+                extras: extras,
+                fingerprint: ScrobbleStartFailure.Fingerprint);
+        }
+
+        /// <summary>
         /// Captures a scrobble failure. The message is the Sentry issue fingerprint, so game name,
         /// user id and session id are attached as a breadcrumb rather than interpolated into it:
         /// putting a game title in the title split one failure mode into a separate issue per game
         /// (making the real rate invisible) and published a per-title event stream nobody asked for.
         /// The context is still available on the event, just not as its identity.
         /// </summary>
-        private static void CaptureSentryMessage(string message, SentryLevel level, string gameName = null, string userId = null, string sessionId = null) {
+        private static void CaptureSentryMessage(
+            string message,
+            SentryLevel level,
+            string gameName = null,
+            string userId = null,
+            string sessionId = null,
+            Dictionary<string, string> extras = null,
+            IReadOnlyCollection<string> fingerprint = null) {
             var data = new Dictionary<string, string>();
             if (!string.IsNullOrEmpty(gameName)) {
                 data["game"] = gameName;
@@ -864,7 +921,7 @@ namespace GsPlugin.Api {
             if (data.Count > 0) {
                 GsSentry.AddBreadcrumb(message: "scrobble failure context", category: "scrobble", data: data);
             }
-            GsSentry.CaptureMessage(message, level);
+            GsSentry.CaptureMessage(message, level, fingerprint, extras);
         }
 
         private async Task<TResponse> GetJsonAsync<TResponse>(string url) where TResponse : class {
@@ -956,7 +1013,8 @@ namespace GsPlugin.Api {
         /// Opt-in so endpoints whose callers only test for null keep their current behaviour.
         /// </param>
         private async Task<TResponse> PostJsonAsync<TResponse>(string url, object payload, bool ensureSuccess = false,
-            Action<int> onStatus = null, bool parseErrorBody = false)
+            Action<int> onStatus = null, bool parseErrorBody = false,
+            HttpCallDiagnostics diagnostics = null, bool captureExceptions = true)
             where TResponse : class {
             string jsonData = JsonSerializer.Serialize(payload, _jsonOptions);
 
@@ -1004,6 +1062,7 @@ namespace GsPlugin.Api {
                                 : responseBody;
                         _logger.Warn(
                             $"POST {url} returned {(int)response.StatusCode} ({response.StatusCode}): {body}");
+                        diagnostics?.SetFailure("http");
 
                         if (ensureSuccess) {
                             var httpEx = new HttpRequestException(
@@ -1037,6 +1096,7 @@ namespace GsPlugin.Api {
                     // Validate response body before deserialization
                     if (string.IsNullOrWhiteSpace(responseBody)) {
                         _logger.Warn($"Received empty response body from {url}");
+                        diagnostics?.SetFailure("empty");
                         return null;
                     }
 
@@ -1045,6 +1105,7 @@ namespace GsPlugin.Api {
                     var contentType = response?.Content?.Headers?.ContentType?.MediaType;
                     if (contentType != null && contentType.Contains("html")) {
                         _logger.Warn($"POST {url} returned HTML content-type instead of JSON — likely a proxy error page");
+                        diagnostics?.SetFailure("html");
                         return null;
                     }
 
@@ -1052,11 +1113,13 @@ namespace GsPlugin.Api {
                         var deserializedResponse = JsonSerializer.Deserialize<TResponse>(responseBody, _jsonOptions);
                         if (deserializedResponse == null) {
                             _logger.Warn($"Deserialization returned null for {url}. Response: {responseBody}");
+                            diagnostics?.SetFailure("json");
                         }
                         return deserializedResponse;
                     }
                     catch (JsonException jsonEx) {
                         _logger.Error(jsonEx, $"Failed to deserialize JSON response from {url}. Response body starts with: {(responseBody.Length > 100 ? responseBody.Substring(0, 100) : responseBody)}");
+                        diagnostics?.SetFailure("json", jsonEx);
                         return null;
                     }
                 }
@@ -1066,7 +1129,14 @@ namespace GsPlugin.Api {
                         responseData: $"Error: {ex.Message}\nStack Trace: {ex.StackTrace}",
                         isError: true);
 
-                    CaptureHttpException(ex, url, jsonData, response, responseBody);
+                    var kind = ex is TaskCanceledException || ex is TimeoutException
+                        ? "timeout"
+                        : "transport";
+                    diagnostics?.SetFailure(kind, ex);
+                    _logger.Warn(ex, $"POST {url} {kind} error: {ex.GetType().Name}");
+                    if (captureExceptions) {
+                        CaptureHttpException(ex, url, jsonData, response, responseBody);
+                    }
                     return null;
                 }
             }
@@ -1184,5 +1254,78 @@ namespace GsPlugin.Api {
         }
 
         #endregion
+    }
+
+    /// <summary>
+    /// Per-attempt notes from <see cref="GsApiClient"/>'s POST helper so a null
+    /// envelope can still say why the call failed (status, exception, kind).
+    /// </summary>
+    internal sealed class HttpCallDiagnostics {
+        public int StatusCode { get; set; }
+        public string FailureKind { get; set; }
+        public string ExceptionType { get; set; }
+
+        public void Reset() {
+            StatusCode = 0;
+            FailureKind = null;
+            ExceptionType = null;
+        }
+
+        public void SetFailure(string kind, Exception ex = null) {
+            FailureKind = kind;
+            if (ex != null) {
+                ExceptionType = ex.GetType().Name;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Stable identity for the null-envelope scrobble-start path (GS-PLAYNITE-M5
+    /// and siblings). Game titles never enter the message or fingerprint.
+    /// </summary>
+    internal static class ScrobbleStartFailure {
+        public const string Message = "Failed to start scrobble session";
+
+        public static readonly string[] Fingerprint = { "gs-playnite", "scrobble-start-failed" };
+
+        /// <summary>
+        /// Report once on the live start path after the HTTP helper actually ran.
+        /// Circuit-open skips and pending-queue flush retries only log locally.
+        /// </summary>
+        public static bool ShouldCapture(int attempts, bool isFlushRetry) =>
+            attempts > 0 && !isFlushRetry;
+
+        public static Dictionary<string, string> BuildExtras(
+            int attempts, HttpCallDiagnostics diagnostics, string outcome) {
+            string kind;
+            if (attempts <= 0) {
+                kind = "circuit";
+            }
+            else if (!string.IsNullOrEmpty(diagnostics?.FailureKind)) {
+                kind = diagnostics.FailureKind;
+            }
+            else if (diagnostics != null && diagnostics.StatusCode >= 400) {
+                kind = "http";
+            }
+            else {
+                kind = "unknown";
+            }
+
+            var extras = new Dictionary<string, string> {
+                { "failure_kind", kind },
+                { "attempts", attempts.ToString() },
+                { "retry_count", Math.Max(0, attempts - 1).ToString() }
+            };
+            if (diagnostics != null && diagnostics.StatusCode > 0) {
+                extras["http_status"] = diagnostics.StatusCode.ToString();
+            }
+            if (!string.IsNullOrEmpty(diagnostics?.ExceptionType)) {
+                extras["exception_type"] = diagnostics.ExceptionType;
+            }
+            if (!string.IsNullOrEmpty(outcome)) {
+                extras["outcome"] = outcome;
+            }
+            return extras;
+        }
     }
 }

--- a/Api/GsApiClient.cs
+++ b/Api/GsApiClient.cs
@@ -194,7 +194,7 @@ namespace GsPlugin.Api {
                             startData.game_name,
                             startData.user_id,
                             extras: ScrobbleStartFailure.BuildExtras(
-                                attempts, diagnostics, envelope.Outcome.ToString()),
+                                attempts, diagnostics, envelope.Outcome.ToString(), startData.game_name),
                             fingerprint: new[] { "gs-playnite", "scrobble-start-fail", envelope.code ?? "unknown" });
                     }
                     return null;
@@ -871,17 +871,14 @@ namespace GsPlugin.Api {
         /// </summary>
         private static void ReportNullEnvelopeStartFailure(
             ScrobbleStartReq startData, bool isFlushRetry, int attempts, HttpCallDiagnostics diagnostics) {
-            var extras = ScrobbleStartFailure.BuildExtras(attempts, diagnostics, outcome: null);
+            var extras = ScrobbleStartFailure.BuildExtras(
+                attempts, diagnostics, outcome: null, startData?.game_name);
             extras.TryGetValue("failure_kind", out var reason);
             GsLogger.Error(
                 $"Failed to start scrobble session (reason={reason ?? "unknown"}, http={diagnostics?.StatusCode ?? 0}, attempts={attempts})");
 
             if (!ScrobbleStartFailure.ShouldCapture(attempts, isFlushRetry)) {
                 return;
-            }
-
-            if (!string.IsNullOrEmpty(startData?.game_name)) {
-                extras["game"] = startData.game_name;
             }
 
             CaptureSentryMessage(
@@ -1296,7 +1293,7 @@ namespace GsPlugin.Api {
             attempts > 0 && !isFlushRetry;
 
         public static Dictionary<string, string> BuildExtras(
-            int attempts, HttpCallDiagnostics diagnostics, string outcome) {
+            int attempts, HttpCallDiagnostics diagnostics, string outcome, string gameName = null) {
             string kind;
             if (attempts <= 0) {
                 kind = "circuit";
@@ -1324,6 +1321,9 @@ namespace GsPlugin.Api {
             }
             if (!string.IsNullOrEmpty(outcome)) {
                 extras["outcome"] = outcome;
+            }
+            if (!string.IsNullOrEmpty(gameName)) {
+                extras["game"] = gameName;
             }
             return extras;
         }

--- a/GsPlugin.Tests/GsApiClientHttpTests.cs
+++ b/GsPlugin.Tests/GsApiClientHttpTests.cs
@@ -99,6 +99,88 @@ namespace GsPlugin.Tests {
                 });
 
                 Assert.Null(result);
+                // Transient 5xx stays retryable (initial + 2 retries).
+                Assert.Equal(3, handler.CallCount);
+            }
+        }
+
+        [Fact]
+        public async Task StartGameSession_PermanentFailEnvelope_DoesNotRetry() {
+            using (var temp = TempPluginDir.CreateWithDataManager("test-token")) {
+                var handler = new MockHttpHandler {
+                    StatusCode = HttpStatusCode.BadRequest,
+                    ResponseBody = JsonSerializer.Serialize(new {
+                        status = "fail",
+                        code = "UNSUPPORTED_PLUGIN",
+                        message = "plugin not allowed"
+                    })
+                };
+                var client = new GsApiClient(new HttpClient(handler));
+
+                var result = await client.StartGameSession(new ScrobbleStartReq {
+                    user_id = "user-1",
+                    game_name = "Test",
+                    game_id = "g1",
+                    plugin_id = "p1"
+                });
+
+                Assert.Null(result);
+                Assert.Equal(1, handler.CallCount);
+            }
+        }
+
+        [Fact]
+        public async Task StartGameSession_TypedErrorEnvelope_DoesNotRetry() {
+            using (var temp = TempPluginDir.CreateWithDataManager("test-token")) {
+                var handler = new MockHttpHandler {
+                    ResponseBody = JsonSerializer.Serialize(new {
+                        status = "error",
+                        code = "INTERNAL",
+                        message = "start failed"
+                    })
+                };
+                var client = new GsApiClient(new HttpClient(handler));
+
+                var result = await client.StartGameSession(new ScrobbleStartReq {
+                    user_id = "user-1",
+                    game_name = "Test",
+                    game_id = "g1",
+                    plugin_id = "p1"
+                });
+
+                Assert.Null(result);
+                Assert.Equal(1, handler.CallCount);
+            }
+        }
+
+        [Fact]
+        public async Task StartGameSession_OpenCircuit_SkipsHttp() {
+            using (var temp = TempPluginDir.CreateWithDataManager("test-token")) {
+                var handler = new MockHttpHandler {
+                    StatusCode = HttpStatusCode.InternalServerError,
+                    ResponseBody = "{\"error\":\"internal\"}"
+                };
+                var breaker = new GsCircuitBreaker(
+                    failureThreshold: 1, timeout: TimeSpan.FromMinutes(2));
+                var client = new GsApiClient(new HttpClient(handler), breaker);
+
+                Assert.Null(await client.StartGameSession(new ScrobbleStartReq {
+                    user_id = "user-1",
+                    game_name = "Test",
+                    game_id = "g1",
+                    plugin_id = "p1"
+                }));
+                var callsAfterFirst = handler.CallCount;
+                Assert.True(callsAfterFirst >= 1);
+                Assert.Equal(GsCircuitBreaker.CircuitState.Open, breaker.State);
+
+                Assert.Null(await client.StartGameSession(new ScrobbleStartReq {
+                    user_id = "user-1",
+                    game_name = "Another Game",
+                    game_id = "g2",
+                    plugin_id = "p1"
+                }));
+                Assert.Equal(callsAfterFirst, handler.CallCount);
             }
         }
 

--- a/GsPlugin.Tests/ScrobbleStartFailureTests.cs
+++ b/GsPlugin.Tests/ScrobbleStartFailureTests.cs
@@ -41,6 +41,18 @@ namespace GsPlugin.Tests {
         }
 
         [Fact]
+        public void BuildExtras_AttachesGameNameWithoutTouchingMessage() {
+            var extras = ScrobbleStartFailure.BuildExtras(
+                1, new HttpCallDiagnostics { StatusCode = 400, FailureKind = "http" },
+                "Fail", "Aliens: Fireteam Elite 2");
+
+            Assert.Equal("Aliens: Fireteam Elite 2", extras["game"]);
+            Assert.Equal("Fail", extras["outcome"]);
+            Assert.DoesNotContain("Aliens", ScrobbleStartFailure.Message);
+            Assert.DoesNotContain("Game:", ScrobbleStartFailure.Message);
+        }
+
+        [Fact]
         public void BuildExtras_IncludesHttpStatusOutcomeAndException() {
             var extras = ScrobbleStartFailure.BuildExtras(3, new HttpCallDiagnostics {
                 StatusCode = 503,

--- a/GsPlugin.Tests/ScrobbleStartFailureTests.cs
+++ b/GsPlugin.Tests/ScrobbleStartFailureTests.cs
@@ -1,0 +1,72 @@
+using System;
+using GsPlugin.Api;
+using Xunit;
+
+namespace GsPlugin.Tests {
+    public class ScrobbleStartFailureTests {
+        [Fact]
+        public void Message_DoesNotIncludeGameOrUserIdentity() {
+            Assert.Equal("Failed to start scrobble session", ScrobbleStartFailure.Message);
+            Assert.DoesNotContain("Game:", ScrobbleStartFailure.Message);
+            Assert.DoesNotContain("[", ScrobbleStartFailure.Message);
+        }
+
+        [Fact]
+        public void Fingerprint_IsStableAndIndependentOfGame() {
+            Assert.Equal(new[] { "gs-playnite", "scrobble-start-failed" }, ScrobbleStartFailure.Fingerprint);
+        }
+
+        [Theory]
+        [InlineData(0, false, false)]
+        [InlineData(0, true, false)]
+        [InlineData(1, true, false)]
+        [InlineData(3, true, false)]
+        [InlineData(1, false, true)]
+        [InlineData(3, false, true)]
+        public void ShouldCapture_OnlyLivePathAfterAnAttempt(
+            int attempts, bool isFlushRetry, bool expected) {
+            Assert.Equal(expected, ScrobbleStartFailure.ShouldCapture(attempts, isFlushRetry));
+        }
+
+        [Fact]
+        public void BuildExtras_CircuitSkip_ClassifiesAsCircuit() {
+            var extras = ScrobbleStartFailure.BuildExtras(0, new HttpCallDiagnostics(), null);
+
+            Assert.Equal("circuit", extras["failure_kind"]);
+            Assert.Equal("0", extras["attempts"]);
+            Assert.Equal("0", extras["retry_count"]);
+            Assert.False(extras.ContainsKey("http_status"));
+            Assert.False(extras.ContainsKey("exception_type"));
+            Assert.False(extras.ContainsKey("game"));
+        }
+
+        [Fact]
+        public void BuildExtras_IncludesHttpStatusOutcomeAndException() {
+            var extras = ScrobbleStartFailure.BuildExtras(3, new HttpCallDiagnostics {
+                StatusCode = 503,
+                FailureKind = "timeout",
+                ExceptionType = nameof(TimeoutException)
+            }, "Error");
+
+            Assert.Equal("timeout", extras["failure_kind"]);
+            Assert.Equal("3", extras["attempts"]);
+            Assert.Equal("2", extras["retry_count"]);
+            Assert.Equal("503", extras["http_status"]);
+            Assert.Equal(nameof(TimeoutException), extras["exception_type"]);
+            Assert.Equal("Error", extras["outcome"]);
+            foreach (var value in extras.Values) {
+                Assert.DoesNotContain("Game:", value ?? "");
+            }
+        }
+
+        [Fact]
+        public void BuildExtras_HttpStatusWithoutKind_FallsBackToHttp() {
+            var extras = ScrobbleStartFailure.BuildExtras(1, new HttpCallDiagnostics {
+                StatusCode = 502
+            }, null);
+
+            Assert.Equal("http", extras["failure_kind"]);
+            Assert.Equal("502", extras["http_status"]);
+        }
+    }
+}

--- a/GsPlugin.Tests/SuccessStoryFileReaderTests.cs
+++ b/GsPlugin.Tests/SuccessStoryFileReaderTests.cs
@@ -72,6 +72,24 @@ namespace GsPlugin.Tests {
         }
 
         [Fact]
+        public void GetAchievements_ParsesUtf8BomFile() {
+            var gameId = Guid.NewGuid();
+            var json = @"{""Items"":[{""Name"":""Bommed"",""DateUnlocked"":""2025-06-01T12:00:00Z"",""Percent"":1.0}]}";
+            var bytes = System.Text.Encoding.UTF8.GetPreamble()
+                .Concat(System.Text.Encoding.UTF8.GetBytes(json))
+                .ToArray();
+            File.WriteAllBytes(Path.Combine(_tempDir, $"{gameId}.json"), bytes);
+
+            var helper = CreateHelper();
+            var result = helper.GetAchievements(gameId);
+
+            Assert.NotNull(result);
+            Assert.Single(result);
+            Assert.Equal("Bommed", result[0].Name);
+            Assert.True(result[0].IsUnlocked);
+        }
+
+        [Fact]
         public void GetAchievements_ParsesUnlockedAchievement() {
             var gameId = Guid.NewGuid();
             var json = @"{

--- a/Infrastructure/GsSentry.cs
+++ b/Infrastructure/GsSentry.cs
@@ -414,7 +414,16 @@ namespace GsPlugin.Infrastructure {
         /// </summary>
         /// <param name="message">The message to capture.</param>
         /// <param name="level">The severity level of the message.</param>
-        public static void CaptureMessage(string message, SentryLevel level = SentryLevel.Info) {
+        /// <param name="fingerprint">
+        /// Optional explicit issue fingerprint. Use this when the message must stay
+        /// stable (or when extras vary) so Sentry does not split one failure mode.
+        /// </param>
+        /// <param name="extras">Optional diagnostic key/value pairs attached to the event.</param>
+        public static void CaptureMessage(
+            string message,
+            SentryLevel level = SentryLevel.Info,
+            IReadOnlyCollection<string> fingerprint = null,
+            IReadOnlyDictionary<string, string> extras = null) {
             if (!_initialized || _consent?.IsAllowed != true) return;
             // Skip if Sentry is disabled, data not yet initialized, or user opted out
             var data = GsDataManager.DataOrNull;
@@ -426,6 +435,16 @@ namespace GsPlugin.Infrastructure {
                     scope.Level = level;
                     scope.SetTag("installId", data.InstallID);
                     scope.SetTag("LinkedUserId", data.LinkedUserId);
+                    if (fingerprint != null && fingerprint.Count > 0) {
+                        scope.SetFingerprint(fingerprint);
+                    }
+                    if (extras != null) {
+                        foreach (var kv in extras) {
+                            if (!string.IsNullOrEmpty(kv.Key) && kv.Value != null) {
+                                scope.SetExtra(kv.Key, kv.Value);
+                            }
+                        }
+                    }
                 });
             }
             catch (Exception ex) { try { _logger.Debug(ex, "Sentry CaptureMessage failed (non-critical)"); } catch { } }

--- a/Services/GsSuccessStoryHelper.cs
+++ b/Services/GsSuccessStoryHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using Playnite.SDK;
 
@@ -43,16 +44,18 @@ namespace GsPlugin.Services {
             var filePath = Path.Combine(_dataPath, $"{gameId}.json");
             if (!File.Exists(filePath)) return null;
 
-            byte[] fileBytes;
+            // Read as text and parse the string overload. JsonDocument.Parse(byte[]) /
+            // Parse(ReadOnlyMemory<byte>) is missing from older System.Text.Json builds
+            // that another Playnite extension may already have loaded into this AppDomain
+            // (GS-PLAYNITE-PE). Parse(string) has existed since 4.6.0.
+            string json;
             using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read,
-                       FileShare.ReadWrite | FileShare.Delete)) {
-                using (var ms = new MemoryStream()) {
-                    stream.CopyTo(ms);
-                    fileBytes = ms.ToArray();
-                }
+                       FileShare.ReadWrite | FileShare.Delete))
+            using (var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true)) {
+                json = reader.ReadToEnd();
             }
 
-            using (var doc = JsonDocument.Parse(fileBytes)) {
+            using (var doc = JsonDocument.Parse(json)) {
                 var root = doc.RootElement;
 
                 if (root.TryGetProperty("IsIgnored", out var ignored) && ignored.GetBoolean())
@@ -101,6 +104,7 @@ namespace GsPlugin.Services {
         protected override string DescribeAchievementReadFailure(Exception ex) {
             if (ex is JsonException) return "JSON parse error";
             if (ex is IOException) return "File read error";
+            if (ex is MissingMethodException) return "Incompatible JSON parser";
             return null;
         }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes production Playnite scrobble-start Sentry noise and the SuccessStory `MissingMethodException` on achievement sync.

### Scrobble start (GS-PLAYNITE-M5, [9C](https://game-scrobbler.sentry.io/issues/GS-PLAYNITE-9C), [M6](https://game-scrobbler.sentry.io/issues/GS-PLAYNITE-M6), [M4](https://game-scrobbler.sentry.io/issues/GS-PLAYNITE-M4))

Live events on `GsPlugin@2.8.2` still use `Failed to start scrobble session [Game: …]`, which splits one transport/null-envelope failure into a separate issue per title. Main already stopped interpolating the game name into the message; this PR finishes the client-side work:

- Record **HTTP status, failure kind, exception type, attempt/retry count** on the POST helper so a null envelope is no longer opaque.
- Parse typed `fail`/`error` bodies on permanent 4xx instead of collapsing them into the generic null path.
- Treat `ApiOutcome.Error` as a typed rejection.
- **Do not send Sentry** when the circuit breaker skips the call, or on pending-queue flush retries (the 5-minute timer was the volume source for always-on games).
- Capture the live-path null envelope once with a **stable fingerprint** (`gs-playnite` / `scrobble-start-failed`). Game name stays on breadcrumbs/extras only.
- Stop capturing a transport exception on every retry of this path (one classified message instead).

A sibling change on `gs-mono` should keep `/api/playnite/v3/scrobble/start` from silently dropping or 5xx-ing valid starts. The plugin now surfaces real HTTP/API outcomes when the server does answer.

### Achievement sync ([GS-PLAYNITE-PE](https://game-scrobbler.sentry.io/issues/GS-PLAYNITE-PE))

`JsonDocument.Parse(byte[])` binds to `Parse(ReadOnlyMemory<byte>, JsonDocumentOptions)`, which is missing when another Playnite extension has already loaded an older `System.Text.Json` into the shared AppDomain. SuccessStory files are now read as text and parsed with `Parse(string)` (present since 4.6.0). `MissingMethodException` is also named in the provider’s failure wording if it still occurs.

## Test plan

- [x] Unit tests for fingerprint stability, capture gating (live vs flush vs circuit), and extras classification
- [x] HTTP tests: 5xx retries, permanent 4xx fail envelope (no retry), typed `error` envelope, open-circuit skip
- [x] SuccessStory reader: existing parse cases plus UTF-8 BOM
- [x] CI `dotnet test` on windows-2022 ([Release Build](https://github.com/game-scrobbler/gs-playnite/actions/runs/33997230958))

## Sentry

- https://game-scrobbler.sentry.io/issues/GS-PLAYNITE-M5
- https://game-scrobbler.sentry.io/issues/GS-PLAYNITE-9C
- https://game-scrobbler.sentry.io/issues/GS-PLAYNITE-M6
- https://game-scrobbler.sentry.io/issues/GS-PLAYNITE-M4
- https://game-scrobbler.sentry.io/issues/GS-PLAYNITE-PE

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0f1cb3e-5bd6-4dd8-a80b-86f9bef1fa19?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0f1cb3e-5bd6-4dd8-a80b-86f9bef1fa19&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of game-session startup failures, including retries, server errors, circuit-breaker skips, and clearer diagnostics.
  * Prevented duplicate error reporting during retry attempts.
  * Improved compatibility when reading achievement files containing a UTF-8 byte-order mark.
  * Added clearer reporting for incompatible JSON parser environments.

* **Diagnostics**
  * Added richer error context and more consistent grouping for reported startup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->