### PR TITLE
docs(theme): document the embeddable dashboard control

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,30 @@ Auth via `x-profile-token` header or `profile_token` parameter.
 
 ---
 
+## Theme Integration
+
+The dashboard is exposed as a custom element, so theme developers can place it anywhere in a **Desktop or Fullscreen** theme. This is how GameScrobbler becomes usable in Fullscreen mode, which has no sidebar.
+
+Add this to your theme XAML:
+
+```xml
+<ContentControl x:Name="GameScrobbler_Dashboard" />
+```
+
+Playnite renders the dashboard wherever you place the control, and your layout controls its position and size. Nothing else is required: no configuration, and no reference to the plugin assembly.
+
+Notes:
+
+- The element resolves only when the Game Scrobbler plugin is installed and enabled. If the user has opted out of data collection, the control renders nothing.
+- The same dashboard is used on every surface (sidebar, Extensions menu, and your theme), so users see consistent content wherever it appears.
+- The control disposes itself when unloaded, so theme reloads and view changes are safe.
+
+**Current limitation:** this embeds the *whole* dashboard as a single web view. You can position and size it, but you cannot restyle its internals or place individual pieces (the Dossier board, the AI Roast text, specific stats) separately in your theme's own visual language.
+
+Finer-grained integration is being scoped in [#74](https://github.com/game-scrobbler/gs-playnite/issues/74), either as native WPF widgets that inherit your theme's styles or as bindable data you render yourself. If you build themes, that issue is the place to say which pieces you want and which of the two approaches suits you.
+
+---
+
 ## Achievement Sync
 
 GameScrobbler can aggregate achievement progress from multiple Playnite addons.


### PR DESCRIPTION
## Why

The theme-embeddable dashboard shipped in **2.8.0** (`AddCustomElementSupport`, `GetGameViewControl`) and is the answer to #74, the request for Fullscreen support. Until now the only place that fact was written down was `CLAUDE.md`.

That left the feature undiscoverable by exactly the audience it was built for. A theme developer reading the README had no way to learn that the element exists, what it is named, or that embedding it is what makes the plugin usable in Fullscreen mode, which has no sidebar and was the whole reason the hook was added.

## What

A `## Theme Integration` section in the README, placed with the other developer-facing integration docs (after Public API & MCP), covering:

- The one line a theme needs: `<ContentControl x:Name="GameScrobbler_Dashboard" />`
- That it works in both Desktop and Fullscreen themes, and that no configuration or assembly reference is required
- That the element renders nothing when the plugin is absent or the user has opted out
- That the control self-disposes on `Unloaded`, so theme reloads and view changes are safe

It also states the current ceiling in the same place rather than letting a theme developer discover it by hitting it: this embeds the whole dashboard as a single web view, so a theme can position and size it but cannot restyle its internals or place individual pieces separately. Readers who want that are pointed at #74, where the two candidate approaches (native WPF widgets vs. bindable data) are still open for feedback.

## Notes

Documentation only. No code, no behavior change.

Refs #74


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for theme developers on embedding the dashboard custom element in Desktop and Fullscreen themes.
  - Documented behavior when the plugin is unavailable or opted out, consistency across surfaces, and automatic cleanup on unload.
  - Noted current styling limitations and linked to an issue for future, more granular integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->