### PR TITLE
fix(sync): make v4 upload failures diagnosable in the log

### DIFF
--- a/GsPlugin.Tests/GsSyncHashIndexTests.cs
+++ b/GsPlugin.Tests/GsSyncHashIndexTests.cs
@@ -656,6 +656,49 @@ namespace GsPlugin.Tests {
                     <= 5 * 1024 * 1024));
         }
 
+        // gs-playnite#89: the only trace of a days-long sync outage a user could send us was
+        // "Library v4 commit failed: status=" three times over. A response that never arrived and a
+        // response the server rejected have to read differently or the log cannot start a diagnosis.
+        [Fact]
+        public void DescribeV4Failure_NoResponse_PointsAtTheHttpLogLineInsteadOfAnEmptyStatus() {
+            var described = GsScrobblingService.DescribeV4Failure(
+                responded: false, status: null, error: null, message: null, reason: null);
+
+            Assert.DoesNotContain("status=", described);
+            Assert.Contains("no usable response", described);
+        }
+
+        [Fact]
+        public void DescribeV4Failure_ResponseWithoutStatus_SaysNoneRatherThanNothing() {
+            var described = GsScrobblingService.DescribeV4Failure(
+                responded: true, status: null, error: null, message: null, reason: null);
+
+            Assert.Equal("status=(none)", described);
+        }
+
+        [Fact]
+        public void DescribeV4Failure_IncludesEveryFieldTheServerSet() {
+            var described = GsScrobblingService.DescribeV4Failure(
+                responded: true,
+                status: "rejected",
+                error: "HASH_MISMATCH",
+                message: "recomputed digest did not match",
+                reason: "hash_mismatch");
+
+            Assert.Equal(
+                "status=rejected, error=HASH_MISMATCH, reason=hash_mismatch, "
+                    + "message=recomputed digest did not match",
+                described);
+        }
+
+        [Fact]
+        public void DescribeV4Failure_OmitsFieldsTheServerLeftUnset() {
+            var described = GsScrobblingService.DescribeV4Failure(
+                responded: true, status: "rejected", error: null, message: null, reason: "cooldown");
+
+            Assert.Equal("status=rejected, reason=cooldown", described);
+        }
+
         [Fact]
         public async Task UploadAchievementsFullChunked_ItemOverByteLimit_AbortsWithoutSendingChunk() {
             var mock = new TrackingMockApiClient();

--- a/Services/GsScrobblingService.cs
+++ b/Services/GsScrobblingService.cs
@@ -556,6 +556,38 @@ namespace GsPlugin.Services {
         }
 
         /// <summary>
+        /// Renders a v4 begin/chunk/commit failure for the local log.
+        ///
+        /// A null response and a server rejection are different outages with different fixes, and
+        /// interpolating <c>response?.status</c> collapsed both into the same empty <c>status=</c>.
+        /// That is what a user reporting a days-long sync outage was able to send us in
+        /// gs-playnite#89: three identical "commit failed: status=" lines that could not say whether
+        /// the server had answered at all. A null response means the API client already logged the
+        /// HTTP status and body it saw, so point the reader at that line instead of printing nothing;
+        /// a response that arrived carries the server's own status/error/reason/message, so print
+        /// whichever of them the server actually set.
+        /// </summary>
+        internal static string DescribeV4Failure(
+            bool responded, string status, string error, string message, string reason) {
+            if (!responded) {
+                return "no usable response (see the preceding POST log line for the HTTP status and body)";
+            }
+            var parts = new List<string> {
+                $"status={(string.IsNullOrEmpty(status) ? "(none)" : status)}"
+            };
+            if (!string.IsNullOrEmpty(error)) {
+                parts.Add($"error={error}");
+            }
+            if (!string.IsNullOrEmpty(reason)) {
+                parts.Add($"reason={reason}");
+            }
+            if (!string.IsNullOrEmpty(message)) {
+                parts.Add($"message={message}");
+            }
+            return string.Join(", ", parts);
+        }
+
+        /// <summary>
         /// Generic v4 begin→chunk→commit upload driver shared by the library and achievement
         /// paths. On a begin/chunk failure, a rejected/failed commit, or a thrown exception it
         /// aborts the server-side session so a retry can start fresh rather than being refused
@@ -574,7 +606,8 @@ namespace GsPlugin.Services {
                 var begin = await beginAsync(items.Count);
                 if (begin == null || !begin.success || begin.status != "started"
                     || string.IsNullOrEmpty(begin.sync_id)) {
-                    _logger.Error($"{label} v4 begin failed: status={begin?.status}, error={begin?.error}");
+                    _logger.Error($"{label} v4 begin failed: "
+                        + DescribeV4Failure(begin != null, begin?.status, begin?.error, begin?.message, begin?.reason));
                     return null;
                 }
                 syncId = begin.sync_id;
@@ -592,7 +625,8 @@ namespace GsPlugin.Services {
                 for (var i = 0; i < chunkCount; i++) {
                     var chunkRes = await chunkAsync(syncId, i, chunks[i]);
                     if (chunkRes == null || !chunkRes.success || chunkRes.status != "accepted") {
-                        _logger.Error($"{label} v4 chunk {i} failed: status={chunkRes?.status}");
+                        _logger.Error($"{label} v4 chunk {i + 1}/{chunkCount} failed: "
+                            + DescribeV4Failure(chunkRes != null, chunkRes?.status, chunkRes?.error, chunkRes?.message, null));
                         await abortAsync(syncId);
                         return null;
                     }
@@ -613,7 +647,8 @@ namespace GsPlugin.Services {
                         _logger.Warn($"{label} v4 commit rejected: force-full-sync (reason: {commit.reason})");
                     }
                     else {
-                        _logger.Error($"{label} v4 commit failed: status={commit?.status}");
+                        _logger.Error($"{label} v4 commit failed: "
+                            + DescribeV4Failure(commit != null, commit?.status, null, commit?.message, commit?.reason));
                     }
                     await abortAsync(syncId);
                     return isForceFullSync ? commit : null;


### PR DESCRIPTION
## Why

In #89 a user reported that sync had been broken for days. The log they attached could only say this, three times over:

```
Library v4 commit failed: status=
Failed to queue full library sync.
```

`status=` and nothing after it. Interpolating `commit?.status` collapses two different outages into the same empty string: a response that never arrived, and a response the server rejected. Those have different causes and different fixes, and the log could not distinguish them.

(The underlying rejection in that report was already fixed in 2.8.2 by 4abe345. This is about the fact that the log could not tell us so.)

## What

`DescribeV4Failure` splits the two cases:

- **No response.** The API client already logged the HTTP status and a truncated body, so the line points the reader at it instead of printing an empty field.
- **A response arrived.** Print whichever of the server's own `status` / `error` / `reason` / `message` it actually set, and `status=(none)` when even that is absent.

Applied to `begin`, `chunk` and `commit`, since all three shared the defect and only `begin` logged `error`. Chunk failures now also say which chunk of how many.

## Notes

No behavior change. The same failures fail the same way and abort the same session; they just say why.

Four tests in `GsSyncHashIndexTests` cover the split, including the exact regression from #89 (a null response must not render as an empty `status=`). Full suite: 504 passing.

Refs #89


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization failure messages by distinguishing unavailable server responses from responses containing errors.
  * Failure details now clearly show available status, error, reason, and message information.
  * Chunk-related errors now identify the affected chunk using one-based numbering.
  * Existing full-sync behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->