### PR TITLE
fix: give a locked file long enough to be retried

### DIFF
--- a/GsPlugin.Tests/GsAtomicFileRetryTests.cs
+++ b/GsPlugin.Tests/GsAtomicFileRetryTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+using GsPlugin.Infrastructure;
+using Xunit;
+
+namespace GsPlugin.Tests {
+    /// <summary>
+    /// Pins the retry budget <see cref="GsAtomicFile"/> gives a transient Windows sharing
+    /// violation.
+    ///
+    /// The budget used to be three attempts over 75 ms, which is not enough for the antivirus and
+    /// indexer scans the retry exists for. Driving the shipped WriteJson through a save forced to
+    /// fail followed by the save that has to succeed lost that race four times in four thousand
+    /// rounds, every one of them "Unable to remove the file to be replaced". In the suite the same
+    /// dice roll surfaced as one unrelated test failing per full run, a different one each time,
+    /// because every assertion about persisted state rides on the save underneath it.
+    /// </summary>
+    public class GsAtomicFileRetryTests {
+        private static readonly JsonSerializerOptions Options = new JsonSerializerOptions();
+
+        private sealed class Payload {
+            public string Value { get; set; }
+        }
+
+        /// <summary>
+        /// The give-up path through the real writer, which is what proves the policy is actually
+        /// wired into WriteJson rather than only into the helper below: a lock that is never
+        /// released must still end in an IOException, and only after the write has spent the
+        /// budget trying. The elapsed-time bound is a lower bound, so load can only push it
+        /// further from the threshold, never towards it.
+        /// </summary>
+        [Fact]
+        public void WriteJson_LockHeldThroughout_ThrowsOnlyAfterSpendingTheRetryBudget() {
+            using (var temp = TempPluginDir.Create()) {
+                var path = Path.Combine(temp.Path, "gs_data.json");
+                File.WriteAllText(path, "{}");
+
+                var stopwatch = Stopwatch.StartNew();
+                using (new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read)) {
+                    Assert.Throws<IOException>(
+                        () => GsAtomicFile.WriteJson(path, new Payload { Value = "new" }, Options));
+                }
+                stopwatch.Stop();
+
+                // 20 + 40 + 80 + 160 + 320 = 620 ms of backoff across six attempts. Asserting well
+                // under that keeps timer granularity out of it while still failing loudly if the
+                // budget is ever cut back towards the 75 ms that lost saves.
+                Assert.True(stopwatch.ElapsedMilliseconds >= 500,
+                    $"Gave up after only {stopwatch.ElapsedMilliseconds} ms; the retry budget is "
+                    + "too thin to survive an antivirus scan.");
+            }
+        }
+
+        /// <summary>
+        /// A lock that clears partway through must be ridden out rather than reported as a failed
+        /// save. Injected rather than timed against a real file handle: whether the writer or the
+        /// thread holding the file wins a given moment is not something a test can schedule, and
+        /// the timed version of this passed against the old 75 ms policy while taking 600 ms,
+        /// which is a test that discriminates nothing and flakes on a loaded machine.
+        /// </summary>
+        [Fact]
+        public void WithRetry_TransientFailuresThenSuccess_IsRiddenOut() {
+            var attempts = 0;
+            GsAtomicFile.WithRetry(() => {
+                if (++attempts < 4) {
+                    throw new IOException("The process cannot access the file");
+                }
+            });
+            Assert.Equal(4, attempts);
+        }
+
+        /// <summary>
+        /// The budget is six attempts, and the last one's exception reaches the caller so
+        /// GsDataManager can roll the mutation back instead of believing a lost write succeeded.
+        /// </summary>
+        [Fact]
+        public void WithRetry_FailureThroughout_TriesSixTimesThenRethrows() {
+            var attempts = 0;
+            Assert.Throws<IOException>(() => GsAtomicFile.WithRetry(() => {
+                attempts++;
+                throw new IOException("The process cannot access the file");
+            }));
+            Assert.Equal(6, attempts);
+        }
+
+        /// <summary>
+        /// Only a sharing violation is worth retrying. Anything else is a real fault that must
+        /// surface on the first attempt rather than being retried six times.
+        /// </summary>
+        [Fact]
+        public void WithRetry_NonIoFailure_IsNotRetried() {
+            var attempts = 0;
+            Assert.Throws<InvalidOperationException>(() => GsAtomicFile.WithRetry(() => {
+                attempts++;
+                throw new InvalidOperationException("not a lock");
+            }));
+            Assert.Equal(1, attempts);
+        }
+
+        /// <summary>
+        /// The ordinary path stays fast. A retry policy that cost anything when nothing is locked
+        /// would be paid on every game start and stop, under GsDataManager's process-wide lock.
+        /// </summary>
+        [Fact]
+        public void WriteJson_NothingLocked_DoesNotPayForTheRetryPolicy() {
+            using (var temp = TempPluginDir.Create()) {
+                var path = Path.Combine(temp.Path, "gs_data.json");
+
+                var stopwatch = Stopwatch.StartNew();
+                for (var i = 0; i < 20; i++) {
+                    GsAtomicFile.WriteJson(path, new Payload { Value = i.ToString() }, Options);
+                }
+                stopwatch.Stop();
+
+                // Generous on purpose. The failure this guards against is the policy running when
+                // nothing is locked, which would cost twenty times 620 ms, so a two second bound
+                // separates it by a wide margin while leaving room for a machine whose antivirus
+                // is scanning every one of these writes. A tight bound here would make this test
+                // the very kind of load-sensitive flake it exists to prevent.
+                Assert.True(stopwatch.ElapsedMilliseconds < 2000,
+                    $"Twenty uncontended writes took {stopwatch.ElapsedMilliseconds} ms, which "
+                    + "means the retry backoff is running on the uncontended path.");
+                var written = JsonSerializer.Deserialize<Payload>(File.ReadAllText(path), Options);
+                Assert.Equal("19", written.Value);
+            }
+        }
+    }
+}

--- a/Infrastructure/GsAtomicFile.cs
+++ b/Infrastructure/GsAtomicFile.cs
@@ -33,25 +33,65 @@ namespace GsPlugin.Infrastructure {
         }
 
         /// <summary>
-        /// Moves/replaces tempPath onto destPath, retrying briefly on IOException. A just-written
-        /// file can be transiently locked (antivirus/indexer scan) on Windows; without a retry
-        /// that sharing violation surfaces as a failed save.
+        /// Attempts allowed for a file operation that can hit a transient Windows sharing
+        /// violation, and the backoff between them: 20, 40, 80, 160, 320 ms, about 620 ms in
+        /// total.
+        ///
+        /// The previous budget was three attempts over 75 ms, which is not enough for the
+        /// antivirus and indexer scans this retry exists for. Driving the shipped WriteJson
+        /// through a save that is forced to fail and then the save that has to succeed lost that
+        /// race four times in four thousand rounds, every one of them "Unable to remove the file
+        /// to be replaced".
+        /// That sequence leaves the .tmp freshly written and abandoned, so it provokes a scan far
+        /// more often than an ordinary save does; treat the figure as the rate for a save retried
+        /// after a failure, not as a field rate. GsDataManager.SaveInternal does report the
+        /// failure to Sentry, but MutateAndSave and Save ignore its result, so the in-memory state
+        /// is kept while the disk copy stays stale.
+        ///
+        /// The cost is paid only while a write is already failing, so the common path is
+        /// unchanged. It is bounded on purpose: GsDataManager saves under a process-wide lock, so
+        /// retrying forever would block every reader including the UI thread.
         /// </summary>
-        public static void ReplaceWithRetry(string tempPath, string destPath, int maxAttempts = 3) {
-            for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+        private const int MaxAttempts = 6;
+
+        private static int BackoffMs(int attempt) => 20 * (1 << (attempt - 1));
+
+        /// <summary>
+        /// Runs a file operation, retrying a transient sharing violation on the schedule above.
+        /// The final attempt's IOException propagates: callers decide what a genuinely failed
+        /// write means, and swallowing it here would hide it from all of them.
+        ///
+        /// Internal rather than private so the retry contract can be tested against an injected
+        /// operation. Timing a real lock cannot pin it: whether the writer or the thread holding
+        /// the file wins a given moment is not something a test can schedule, which makes such a
+        /// test both non-discriminating and flaky.
+        /// </summary>
+        internal static void WithRetry(Action operation) {
+            for (var attempt = 1; attempt <= MaxAttempts; attempt++) {
                 try {
-                    if (File.Exists(destPath)) {
-                        File.Replace(tempPath, destPath, destinationBackupFileName: null);
-                    }
-                    else {
-                        File.Move(tempPath, destPath);
-                    }
+                    operation();
                     return;
                 }
-                catch (IOException) when (attempt < maxAttempts) {
-                    Thread.Sleep(25 * attempt);
+                catch (IOException) when (attempt < MaxAttempts) {
+                    Thread.Sleep(BackoffMs(attempt));
                 }
             }
+        }
+
+        /// <summary>
+        /// Moves/replaces tempPath onto destPath, retrying on IOException. A just-written file can
+        /// be transiently locked (antivirus/indexer scan) on Windows; without a retry that sharing
+        /// violation surfaces as a failed save.
+        /// </summary>
+        public static void ReplaceWithRetry(string tempPath, string destPath) {
+            WithRetry(() => {
+                if (File.Exists(destPath)) {
+                    File.Replace(tempPath, destPath, destinationBackupFileName: null);
+                }
+                else {
+                    File.Move(tempPath, destPath);
+                }
+            });
         }
 
         /// <summary>
@@ -72,10 +112,17 @@ namespace GsPlugin.Infrastructure {
         /// </param>
         public static void WriteJson<T>(string filePath, T value, JsonSerializerOptions options, bool durable = false) {
             var tempPath = filePath + ".tmp";
-            using (var stream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None)) {
-                JsonSerializer.Serialize(stream, value, options);
-                stream.Flush(flushToDisk: durable);
-            }
+            // Opening the temp file gets the same retry as the replace below. A save that just
+            // failed leaves this exact path freshly written and abandoned, which is precisely the
+            // file a scanner is holding, so the open is exposed to the hazard the replace already
+            // defends against. Only the replace has been observed losing the race; this is the
+            // same defect class rather than a second measurement.
+            WithRetry(() => {
+                using (var stream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None)) {
+                    JsonSerializer.Serialize(stream, value, options);
+                    stream.Flush(flushToDisk: durable);
+                }
+            });
             ReplaceWithRetry(tempPath, filePath);
         }
 


### PR DESCRIPTION
Chases down the flake where a full `dotnet test` run failed one test that passed on its own, a different test each time.

## It was not test parallelism

That is already off assembly-wide (`[assembly: CollectionBehavior(DisableTestParallelization = true)]`), and the suspect classes share a `DisableParallelization` collection, so the tests run sequentially. 15 consecutive full-suite runs passed, including 10 with a real MSBuild immediately beforehand to recreate the conditions the observed failures occurred under. Neither an ordering leak nor a race between collections fits.

## What it is

`GsAtomicFile.ReplaceWithRetry` allowed a transient Windows sharing violation three attempts over 75 ms, which is not long enough for the antivirus and indexer scans the retry exists for. A harness drives the **shipped** `WriteJson` out of `bin/Release` by reflection through the sequence those tests perform, a save forced to fail while the file is held open followed by the save that has to succeed:

```
iterations               : 4000
forced failures (step 1) : 4000
UNEXPECTED failures      : 4     <- all "Unable to remove the file to be replaced"
```

One in a thousand. A lost write is not loud: `SaveInternal` reports it to Sentry and returns false, but `MutateAndSave` and `Save` ignore the result, so the in-memory state is kept while the disk copy stays stale. Every assertion about persisted state rides on the save underneath it, which is why a different test drew the short straw each run, and why both originally observed failures landed ~44-45 s into their runs rather than at a fixed test.

## The change

Six attempts, backing off 20, 40, 80, 160, 320 ms. Paid only while a write is already failing, and bounded on purpose because `GsDataManager` saves under a process-wide lock. The temp-file open gets the same retry: a save that just failed leaves that exact path freshly written and abandoned, which is the file a scanner holds. Only the replace has been observed losing the race, and the comment says so rather than implying two measurements.

## Verification

- All five new tests pass against the fix; the three policy-dependent ones fail against the old constant, checked by reverting it and rebuilding.
- Full suite green three times, 535 tests.
- The retry contract is tested against an injected operation, not a real lock. The timed version of that test passed against the old 75 ms policy while taking 600 ms, so it discriminated nothing and would have flaked under load. One test still goes through the real writer to pin that the policy is wired into `WriteJson` and not only into the helper.

## Two things left alone deliberately

- `MutateAndSave` and `Save` discard `SaveInternal`'s result, so a genuinely failed write still leaves memory and disk diverged with only a Sentry report. Widening the retry cuts the probability but does not close it; changing that contract touches every caller.
- There is no "Failed to save GsData to disk" issue in Sentry across all 53 the project has ever recorded, so field impact is inferred from the harness rather than observed. The one-in-a-thousand figure also overstates the field rate, because forcing a failure first provokes a scan far more often than an ordinary save does. Both caveats are in the code comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving files during temporary Windows file-sharing conflicts.
  * Automatically retries transient I/O failures with backoff, while allowing successful operations to continue normally.
  * Preserves immediate handling for non-I/O errors and avoids unnecessary delays when no conflict occurs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->